### PR TITLE
allow to use different configuration when calling application, to all…

### DIFF
--- a/src/FSharpLint.Application/RunLint.fs
+++ b/src/FSharpLint.Application/RunLint.fs
@@ -186,8 +186,8 @@ module RunLint =
 
     let internal neverFinishEarly _ = false
         
-    /// Parses and runs the linter on a single file.
-    let parseFile pathToFile (errorReceived:System.Action<ErrorHandling.Error>) =
+    /// Parses and runs the linter on a single file and a configuration
+    let parseFileWithConfig pathToFile (configuration:FSharpLint.Framework.Configuration.Configuration) (errorReceived:System.Action<ErrorHandling.Error>) =
         let input = System.IO.File.ReadAllText(pathToFile)
 
         let lintInformation =
@@ -201,13 +201,17 @@ module RunLint =
 
         let parsedFileInformation = Ast.parseFile pathToFile lintInformation.Configuration.UseTypeChecker input
 
-        lintFile lintInformation parsedFileInformation
+        lintFile lintInformation parsedFileInformation   
+
+    /// Parses and runs the linter on a single file.
+    let parseFile pathToFile (errorReceived:System.Action<ErrorHandling.Error>) =
+        parseFileWithConfig pathToFile (FSharpLint.Framework.Configuration.loadDefaultConfiguration()) errorReceived
         
-    /// Parses and runs the linter on a string.
-    let parseInput input (errorReceived:System.Action<ErrorHandling.Error>) =
+    /// Parses and runs the linter on a string with config.
+    let parseInputWithConfig input (configuration:FSharpLint.Framework.Configuration.Configuration) (errorReceived:System.Action<ErrorHandling.Error>) =
         let lintInformation =
             {
-                Configuration = FSharpLint.Framework.Configuration.loadDefaultConfiguration()
+                Configuration = configuration
                 RulePlugins = loadPlugins()
                 FinishEarly = neverFinishEarly
                 ErrorReceived = errorReceived.Invoke
@@ -217,3 +221,7 @@ module RunLint =
         let parsedFileInformation = Ast.parseInput lintInformation.Configuration.UseTypeChecker input
 
         lintFile lintInformation parsedFileInformation
+
+    /// Parses and runs the linter on a string.
+    let parseInput input  (errorReceived:System.Action<ErrorHandling.Error>) =
+        parseInputWithConfig input (FSharpLint.Framework.Configuration.loadDefaultConfiguration()) errorReceived

--- a/src/FSharpLint.Application/RunLint.fsi
+++ b/src/FSharpLint.Application/RunLint.fsi
@@ -56,9 +56,15 @@ module RunLint =
         
     /// Parses and runs the linter on all the files in a project.
     val parseProject : projectInformation: ProjectParseInfo -> Result
-        
+    
     /// Parses and runs the linter on a single file.
     val parseFile : pathToFile: string -> errorReceived: System.Action<ErrorHandling.Error> -> unit
-        
+    
+    /// Parses and runs the linter on a single file and configuration    
+    val parseFileWithConfig : pathToFile: string -> FSharpLint.Framework.Configuration.Configuration -> errorReceived: System.Action<ErrorHandling.Error> -> unit
+
     /// Parses and runs the linter on a string.
     val parseInput : input: string -> errorReceived: System.Action<ErrorHandling.Error> -> unit
+
+    /// Parses and runs the linter on a string with congig
+    val parseInputWithConfig : input: string  -> FSharpLint.Framework.Configuration.Configuration -> errorReceived: System.Action<ErrorHandling.Error> -> unit

--- a/src/FSharpLint.Console/FSharpLint.Console.fsproj
+++ b/src/FSharpLint.Console/FSharpLint.Console.fsproj
@@ -79,6 +79,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharpLint.Application\FSharpLint.Application.fsproj">


### PR DESCRIPTION
Hi,

ive created a plugin to support F# in sonar, and use FSharpLint as the main tool to verify coding rules. You can give it a try here https://github.com/jmecosta/sonar-fsharp-plugin/releases/tag/0.9

the relevant requet on Sonar mailing list is here: http://sonarqube.15.x6.nabble.com/fsharp-support-for-sonar-td5035544.html

Since i had the need to create a own console runner to gather sonar metrics, i run into this limitation that i could not overwrite the configuration. My solution for this is to include new methods into the runlint interface that contains the configuration. You can see my solution here: https://github.com/jmecosta/sonar-fsharp-plugin/blob/master/FsSonarRunner/FsSonarRunnerCore/InputConfigHandler.fs 

Now ive just included the application source into my project and applied the change there, but it would be nice to just use dll instead

Is it possible to consider this
thanks in advance

Jorge Costa