### PR TITLE
Add more XmlDoc Rules

### DIFF
--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -223,6 +223,7 @@
             <xs:element name="UnionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="RecordDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="AutoPropertyDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="LetDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -215,6 +215,7 @@
       <xs:element name="Rules" maxOccurs="1" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
+            <xs:element name="ModuleDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="ExceptionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TypeDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="MemberDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -219,6 +219,7 @@
             <xs:element name="ExceptionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TypeDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="MemberDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="EnumDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -220,6 +220,7 @@
             <xs:element name="TypeDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="MemberDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="EnumDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="UnionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -222,6 +222,7 @@
             <xs:element name="EnumDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="UnionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="RecordDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="AutoPropertyDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -221,6 +221,7 @@
             <xs:element name="MemberDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="EnumDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="UnionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="RecordDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -216,6 +216,8 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element name="ExceptionDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="TypeDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="MemberDefinitionHeader" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -363,6 +363,9 @@
         <TypeDefinitionHeader>
           <Enabled>false</Enabled>
         </TypeDefinitionHeader>
+        <MemberDefinitionHeader>
+          <Enabled>false</Enabled>
+        </MemberDefinitionHeader>
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -372,6 +372,12 @@
         <EnumDefinitionHeader>
           <Enabled>false</Enabled>
         </EnumDefinitionHeader>
+        <UnionDefinitionHeader>
+          <Enabled>false</Enabled>
+        </UnionDefinitionHeader>
+        <RecordDefinitionHeader>
+          <Enabled>false</Enabled>
+        </RecordDefinitionHeader>
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -369,6 +369,9 @@
         <MemberDefinitionHeader>
           <Enabled>false</Enabled>
         </MemberDefinitionHeader>
+        <EnumDefinitionHeader>
+          <Enabled>false</Enabled>
+        </EnumDefinitionHeader>
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -357,6 +357,9 @@
     
     <XmlDocumentation>
       <Rules>
+        <ModuleDefinitionHeader>
+          <Enabled>false</Enabled>
+        </ModuleDefinitionHeader>
         <ExceptionDefinitionHeader>
           <Enabled>false</Enabled>
         </ExceptionDefinitionHeader>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -360,6 +360,9 @@
         <ExceptionDefinitionHeader>
           <Enabled>false</Enabled>
         </ExceptionDefinitionHeader>
+        <TypeDefinitionHeader>
+          <Enabled>false</Enabled>
+        </TypeDefinitionHeader>
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -7,7 +7,7 @@
   </IgnoreFiles>
 
   <UseTypeChecker>false</UseTypeChecker>
-  
+
   <Analysers>
     <Hints>
       <Hints>
@@ -22,10 +22,10 @@
           compare x y = -1 ===> x < y
           compare x y <> -1 ===> x >= y
           compare x y = 1 ===> x > y
-                
+
           List.head (List.sort x) ===> List.min x
           List.head (List.sortBy f x) ===> List.minBy f x
-                
+
           List.map f (List.map g x) ===> List.map (g >> f) x
           Array.map f (Array.map g x) ===> Array.map (g >> f) x
           Seq.map f (Seq.map g x) ===> Seq.map (g >> f) x
@@ -48,18 +48,18 @@
           (List.length x) > 0 ===> not (List.isEmpty x)
           (Array.length x) <> 0 ===> not (Array.isEmpty x)
           (Seq.length x) <> 0 ===> not (Seq.isEmpty x)
-                
+
           List.isEmpty (List.filter f x) ===> not (List.exists f x)
           Array.isEmpty (Array.filter f x) ===> not (Array.exists f x)
           Seq.isEmpty (Seq.filter f x) ===> not (Seq.exists f x)
           not (List.isEmpty (List.filter f x)) ===> List.exists f x
           not (Array.isEmpty (Array.filter f x)) ===> Array.exists f x
           not (Seq.isEmpty (Seq.filter f x)) ===> Seq.exists f x
-                
+
           List.length x >= 0 ===> true
           Array.length x >= 0 ===> true
           Seq.length x >= 0 ===> true
-                
+
           x = true ===> x
           x = false ===> not x
           true = a ===> a
@@ -71,9 +71,9 @@
           if a then true else false ===> a
           if a then false else true ===> not a
           not (not x) ===> x
-                
+
           (fst x, snd x) ===> x
-                
+
           true && x ===> x
           false && x ===> false
           true || x ===> true
@@ -89,21 +89,21 @@
           x - 0 ===> x
           x * 1 ===> x
           x / 1 ===> x
-                
+
           List.fold (+) 0 ===> List.sum
           Array.fold (+) 0 ===> Array.sum
           Seq.fold (+) 0 ===> Seq.sum
-                
+
           List.empty ===> []
           Array.empty ===> [||]
-                
+
           x::[] ===> [x]
-                
+
           x @ [] ===> x
-                
+
           List.isEmpty [] ===> true
           Array.isEmpty [||] ===> true
-                
+
           fun _ -> () ===> ignore
           fun x -> x ===> id
           id x ===> x
@@ -119,111 +119,111 @@
         <IdentifiersMustNotContainUnderscores>
           <Enabled>true</Enabled>
         </IdentifiersMustNotContainUnderscores>
-        
+
         <InterfaceNamesMustBeginWithI>
           <Enabled>true</Enabled>
         </InterfaceNamesMustBeginWithI>
-        
+
         <ExceptionNamesMustEndWithException>
           <Enabled>true</Enabled>
         </ExceptionNamesMustEndWithException>
-        
+
         <TypeNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </TypeNamesMustBePascalCase>
-        
+
         <RecordFieldNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </RecordFieldNamesMustBePascalCase>
-        
+
         <EnumCasesMustBePascalCase>
           <Enabled>true</Enabled>
         </EnumCasesMustBePascalCase>
-        
+
         <ModuleNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </ModuleNamesMustBePascalCase>
-        
+
         <LiteralNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </LiteralNamesMustBePascalCase>
-        
+
         <NamespaceNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </NamespaceNamesMustBePascalCase>
-        
+
         <MemberNamesMustBePascalCase>
           <Enabled>true</Enabled>
         </MemberNamesMustBePascalCase>
-        
+
         <ParameterMustBeCamelCase>
           <Enabled>true</Enabled>
         </ParameterMustBeCamelCase>
-        
+
         <NonPublicValuesCamelCase>
           <Enabled>true</Enabled>
         </NonPublicValuesCamelCase>
       </Rules>
       <Enabled>true</Enabled>
     </NameConventions>
-    
+
     <SourceLength>
       <Rules>
         <MaxLinesInFunction>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInFunction>
-        
+
         <MaxLinesInLambdaFunction>
           <Enabled>true</Enabled>
           <Lines>5</Lines>
         </MaxLinesInLambdaFunction>
-        
+
         <MaxLinesInMatchLambdaFunction>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInMatchLambdaFunction>
-        
+
         <MaxLinesInValue>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInValue>
-        
+
         <MaxLinesInConstructor>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInConstructor>
-        
+
         <MaxLinesInMember>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInMember>
-        
+
         <MaxLinesInProperty>
           <Enabled>true</Enabled>
           <Lines>70</Lines>
         </MaxLinesInProperty>
-        
+
         <MaxLinesInClass>
           <Enabled>true</Enabled>
           <Lines>500</Lines>
         </MaxLinesInClass>
-        
+
         <MaxLinesInEnum>
           <Enabled>true</Enabled>
           <Lines>500</Lines>
         </MaxLinesInEnum>
-        
+
         <MaxLinesInUnion>
           <Enabled>true</Enabled>
           <Lines>500</Lines>
         </MaxLinesInUnion>
-        
+
         <MaxLinesInRecord>
           <Enabled>true</Enabled>
           <Lines>500</Lines>
         </MaxLinesInRecord>
-        
+
         <MaxLinesInModule>
           <Enabled>true</Enabled>
           <Lines>1000</Lines>
@@ -231,27 +231,27 @@
       </Rules>
       <Enabled>true</Enabled>
     </SourceLength>
-    
+
     <Typography>
       <Rules>
         <MaxLinesInFile>
           <Enabled>true</Enabled>
           <Lines>1000</Lines>
         </MaxLinesInFile>
-        
+
         <MaxCharactersOnLine>
           <Enabled>true</Enabled>
           <Length>120</Length>
         </MaxCharactersOnLine>
-        
+
         <NoTabCharacters>
           <Enabled>true</Enabled>
         </NoTabCharacters>
-        
+
         <TrailingNewLineInFile>
           <Enabled>true</Enabled>
         </TrailingNewLineInFile>
-        
+
         <TrailingWhitespaceOnLine>
           <Enabled>true</Enabled>
           <NumberOfSpacesAllowed>1</NumberOfSpacesAllowed>
@@ -261,29 +261,29 @@
       </Rules>
       <Enabled>true</Enabled>
     </Typography>
-    
+
     <NestedStatements>
       <Enabled>true</Enabled>
       <Depth>8</Depth>
     </NestedStatements>
-    
+
     <NumberOfItems>
       <Rules>
         <MaxNumberOfFunctionParameters>
           <Enabled>true</Enabled>
           <MaxItems>5</MaxItems>
         </MaxNumberOfFunctionParameters>
-        
+
         <MaxNumberOfMembers>
           <Enabled>true</Enabled>
           <MaxItems>32</MaxItems>
         </MaxNumberOfMembers>
-        
+
         <MaxNumberOfItemsInTuple>
           <Enabled>true</Enabled>
           <MaxItems>4</MaxItems>
         </MaxNumberOfItemsInTuple>
-        
+
         <MaxNumberOfBooleanOperatorsInCondition>
           <Enabled>true</Enabled>
           <MaxItems>4</MaxItems>
@@ -291,7 +291,7 @@
       </Rules>
       <Enabled>true</Enabled>
     </NumberOfItems>
-    
+
     <RaiseWithTooManyArguments>
       <Rules>
         <FailwithWithSingleArgument>
@@ -320,7 +320,7 @@
       </Rules>
       <Enabled>true</Enabled>
     </RaiseWithTooManyArguments>
-    
+
     <Binding>
       <Rules>
         <FavourIgnoreOverLetWild>
@@ -341,7 +341,7 @@
       </Rules>
       <Enabled>true</Enabled>
     </Binding>
-    
+
     <FunctionReimplementation>
       <Rules>
         <ReimplementsFunction>
@@ -354,7 +354,7 @@
       </Rules>
       <Enabled>true</Enabled>
     </FunctionReimplementation>
-    
+
     <XmlDocumentation>
       <Rules>
         <ModuleDefinitionHeader>
@@ -381,7 +381,7 @@
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>
-    
+
     <CyclomaticComplexity>
       <Enabled>true</Enabled>
       <MaxCyclomaticComplexity>10</MaxCyclomaticComplexity>

--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -378,6 +378,9 @@
         <RecordDefinitionHeader>
           <Enabled>false</Enabled>
         </RecordDefinitionHeader>
+        <AutoPropertyDefinitionHeader>
+          <Enabled>false</Enabled>
+        </AutoPropertyDefinitionHeader>
       </Rules>
       <Enabled>false</Enabled>
     </XmlDocumentation>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -267,4 +267,7 @@
   <data name="RulesXmlDocumentationRecordError" xml:space="preserve">
     <value>Expected record case to have xml documentation:</value>
   </data>
+  <data name="RulesXmlDocumentationAutoPropertyError" xml:space="preserve">
+    <value>Expected auto property to have xml documentation:</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -270,4 +270,7 @@
   <data name="RulesXmlDocumentationAutoPropertyError" xml:space="preserve">
     <value>Expected auto property to have xml documentation:</value>
   </data>
+  <data name="RulesXmlDocumentationLetError" xml:space="preserve">
+    <value>Expected let to have xml documentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -259,6 +259,9 @@
     <value>Expected module to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationEnumError" xml:space="preserve">
-    <value>Expected enum to have xml documentation.</value>
+    <value>Expected enum to have xml documentation:</value>
+  </data>
+  <data name="RulesXmlDocumentationUnionError" xml:space="preserve">
+    <value>Expected union case to have xml documentation:</value>
   </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -259,16 +259,16 @@
     <value>Expected module to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationEnumError" xml:space="preserve">
-    <value>Expected enum to have xml documentation:</value>
+    <value>Expected enum {0} to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationUnionError" xml:space="preserve">
-    <value>Expected union case to have xml documentation:</value>
+    <value>Expected union case {0} to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationRecordError" xml:space="preserve">
-    <value>Expected record case to have xml documentation:</value>
+    <value>Expected record case {0} to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationAutoPropertyError" xml:space="preserve">
-    <value>Expected auto property to have xml documentation:</value>
+    <value>Expected auto property {0} to have xml documentation.</value>
   </data>
   <data name="RulesXmlDocumentationLetError" xml:space="preserve">
     <value>Expected let to have xml documentation.</value>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -258,4 +258,7 @@
   <data name="RulesXmlDocumentationModuleError" xml:space="preserve">
     <value>Expected module to have xml documentation.</value>
   </data>
+  <data name="RulesXmlDocumentationEnumError" xml:space="preserve">
+    <value>Expected enum to have xml documentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -255,4 +255,7 @@
   <data name="RulesXmlDocumentationMemberError" xml:space="preserve">
     <value>Expected member to have xml documentation.</value>
   </data>
+  <data name="RulesXmlDocumentationModuleError" xml:space="preserve">
+    <value>Expected module to have xml documentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -249,4 +249,7 @@
   <data name="RulesCanBeReplacedWithComposition" xml:space="preserve">
     <value>Pointless function can be replaced with function composition.</value>
   </data>
+  <data name="RulesXmlDocumentationTypeError" xml:space="preserve">
+    <value>Expected type to have xml documentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -264,4 +264,7 @@
   <data name="RulesXmlDocumentationUnionError" xml:space="preserve">
     <value>Expected union case to have xml documentation:</value>
   </data>
+  <data name="RulesXmlDocumentationRecordError" xml:space="preserve">
+    <value>Expected record case to have xml documentation:</value>
+  </data>
 </root>

--- a/src/FSharpLint.Framework/Text.resx
+++ b/src/FSharpLint.Framework/Text.resx
@@ -252,4 +252,7 @@
   <data name="RulesXmlDocumentationTypeError" xml:space="preserve">
     <value>Expected type to have xml documentation.</value>
   </data>
+  <data name="RulesXmlDocumentationMemberError" xml:space="preserve">
+    <value>Expected member to have xml documentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -85,11 +85,19 @@ module XmlDocumentation =
                 if isPreXmlDocEmpty xmlDoc then
                     visitorInfo.PostError range (getString "RulesXmlDocumentationAutoPropertyError")
 
+        | AstNode.MemberDefinition(SynMemberDefn.LetBindings(synBindings, _, _, range)) ->
+            if ruleEnabled visitorInfo astNode "LetDefinitionHeader" then
+                let evalBinding (SynBinding.Binding(_, _, _, _, _, xmlDoc, _, _, _, _, range, _)) =
+                    if isPreXmlDocEmpty xmlDoc then
+                        visitorInfo.PostError range (getString "RulesXmlDocumentationLetError")
+                synBindings |> List.iter evalBinding
+
         | AstNode.TypeDefinition(SynTypeDefn.TypeDefn(coreInfo, typeDefnRep, _, rng)) ->
             if ruleEnabled visitorInfo astNode "TypeDefinitionHeader" then
                 let (SynComponentInfo.ComponentInfo(_, _, _, _, xmlDoc, _, _, range)) = coreInfo
                 if isPreXmlDocEmpty xmlDoc then
                     visitorInfo.PostError range (getString "RulesXmlDocumentationTypeError")
+
             if ruleEnabled visitorInfo astNode "RecordDefinitionHeader" then
                 let evalField (SynField.Field(_, _, id, _, _, xmlDoc, _, range)) =
                     if isPreXmlDocEmpty xmlDoc then

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -28,7 +28,6 @@ module XmlDocumentation =
     open FSharpLint.Framework.Ast
     open FSharpLint.Framework.Configuration
     open FSharpLint.Framework.LoadVisitors
-    open Microsoft.FSharp.Compiler.Ast
 
     [<Literal>]
     let AnalyserName = "XmlDocumentation"
@@ -73,6 +72,12 @@ module XmlDocumentation =
                     let (SynBinding.Binding(_, _, _, _, _, xmlDoc, _, _, _, _, range, _)) = synBinding
                     if isPreXmlDocEmpty xmlDoc then
                         visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationMemberError"))
+            | AstNode.EnumCase(SynEnumCase.EnumCase(_, id, _, xmlDoc, range)) ->
+                if configExceptionHeader visitorInfo.Config "EnumDefinitionHeader" &&
+                    astNode.IsSuppressed(AnalyserName, "EnumDefinitionHeader") |> not then
+                    if isPreXmlDocEmpty xmlDoc then
+                        visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationEnumError") +
+                            " " + id.idText)
             | _ -> ()
 
         Continue

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -48,7 +48,7 @@ module XmlDocumentation =
                 xs |> atLeastOneThatHasText
             | _ -> false
 
-    let visitor visitorInfo (checkFile:FSharpCheckFileResults) astNode =
+    let visitor visitorInfo checkFile astNode =
         match astNode.Node with
             | AstNode.ExceptionRepresentation(SynExceptionRepr.ExceptionDefnRepr(_, unionCase, _, xmlDoc, _, range)) ->
                 if configExceptionHeader visitorInfo.Config "ExceptionDefinitionHeader" &&

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -80,6 +80,11 @@ module XmlDocumentation =
                 if isPreXmlDocEmpty xmlDoc then
                     visitorInfo.PostError range (getString "RulesXmlDocumentationMemberError")
 
+        | AstNode.MemberDefinition(SynMemberDefn.AutoProperty(_, _, id, _, _, _, xmlDoc, _, _, rangeOpt, range)) ->
+            if ruleEnabled visitorInfo astNode "AutoPropertyDefinitionHeader" then
+                if isPreXmlDocEmpty xmlDoc then
+                    visitorInfo.PostError range (getString "RulesXmlDocumentationAutoPropertyError")
+
         | AstNode.TypeDefinition(SynTypeDefn.TypeDefn(coreInfo, typeDefnRep, _, rng)) ->
             if ruleEnabled visitorInfo astNode "TypeDefinitionHeader" then
                 let (SynComponentInfo.ComponentInfo(_, _, _, _, xmlDoc, _, _, range)) = coreInfo

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -68,22 +68,21 @@ module XmlDocumentation =
 
         | AstNode.EnumCase(SynEnumCase.EnumCase(_, id, _, xmlDoc, range)) ->
             if ruleEnabled visitorInfo astNode "EnumDefinitionHeader" && isPreXmlDocEmpty xmlDoc then
-                visitorInfo.PostError range (getString "RulesXmlDocumentationEnumError" + " " + id.idText)
+                visitorInfo.PostError range (String.Format(getString "RulesXmlDocumentationEnumError", id.idText))
 
         | AstNode.UnionCase(SynUnionCase.UnionCase(_, id, _, xmlDoc, _, range)) ->
             if ruleEnabled visitorInfo astNode "UnionDefinitionHeader" && isPreXmlDocEmpty xmlDoc then
-                visitorInfo.PostError range (getString "RulesXmlDocumentationUnionError" + " " + id.idText)
+                visitorInfo.PostError range (String.Format(getString "RulesXmlDocumentationUnionError", id.idText))
+
+        | AstNode.MemberDefinition(SynMemberDefn.AutoProperty(_, _, id, _, _, _, xmlDoc, _, _, rangeOpt, range)) ->
+            if ruleEnabled visitorInfo astNode "AutoPropertyDefinitionHeader" && isPreXmlDocEmpty xmlDoc then
+                visitorInfo.PostError range (String.Format(getString "RulesXmlDocumentationAutoPropertyError", id.idText))
 
         | AstNode.MemberDefinition(SynMemberDefn.Member(synBinding, _)) ->
             if ruleEnabled visitorInfo astNode "MemberDefinitionHeader" then
                 let (SynBinding.Binding(_, _, _, _, _, xmlDoc, _, _, _, _, range, _)) = synBinding
                 if isPreXmlDocEmpty xmlDoc then
                     visitorInfo.PostError range (getString "RulesXmlDocumentationMemberError")
-
-        | AstNode.MemberDefinition(SynMemberDefn.AutoProperty(_, _, id, _, _, _, xmlDoc, _, _, rangeOpt, range)) ->
-            if ruleEnabled visitorInfo astNode "AutoPropertyDefinitionHeader" then
-                if isPreXmlDocEmpty xmlDoc then
-                    visitorInfo.PostError range (getString "RulesXmlDocumentationAutoPropertyError")
 
         | AstNode.MemberDefinition(SynMemberDefn.LetBindings(synBindings, _, _, range)) ->
             if ruleEnabled visitorInfo astNode "LetDefinitionHeader" then
@@ -101,7 +100,7 @@ module XmlDocumentation =
             if ruleEnabled visitorInfo astNode "RecordDefinitionHeader" then
                 let evalField (SynField.Field(_, _, id, _, _, xmlDoc, _, range)) =
                     if isPreXmlDocEmpty xmlDoc then
-                        visitorInfo.PostError range (getString "RulesXmlDocumentationRecordError" + getIdText id)
+                        visitorInfo.PostError range (String.Format(getString "RulesXmlDocumentationRecordError", getIdText id))
                 match typeDefnRep with
                 | Simple(simple, range) ->
                     match simple with

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -66,6 +66,20 @@ module XmlDocumentation =
                     let (SynComponentInfo.ComponentInfo(_, _, _, _, xmlDoc, _, _, range)) = coreInfo
                     if isPreXmlDocEmpty xmlDoc then
                         visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationTypeError"))
+                if configExceptionHeader visitorInfo.Config "RecordDefinitionHeader" &&
+                    astNode.IsSuppressed(AnalyserName, "RecordDefinitionHeader") |> not then
+                    let evalField (SynField.Field(_, _, id, _, _, xmlDoc, _, range)) =
+                        if isPreXmlDocEmpty xmlDoc then
+                            visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationRecordError")
+                                + (match id with
+                                   | None -> ""
+                                   | Some i -> " " + i.idText))
+                    match typeDefnRep with
+                    | Simple(simple, range) ->
+                        match simple with
+                        | SynTypeDefnSimpleRepr.Record(_, fields, _) -> fields |> List.iter evalField
+                        | _ -> ()
+                    | _ -> ()
             | AstNode.MemberDefinition(SynMemberDefn.Member(synBinding, rng)) ->
                 if configExceptionHeader visitorInfo.Config "MemberDefinitionHeader" &&
                     astNode.IsSuppressed(AnalyserName, "MemberDefinitionHeader") |> not then

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -51,6 +51,11 @@ module XmlDocumentation =
 
     let visitor visitorInfo checkFile astNode =
         match astNode.Node with
+            | AstNode.ModuleOrNamespace(SynModuleOrNamespace.SynModuleOrNamespace(_, _, _, xmlDoc, _, _, range)) ->
+                if configExceptionHeader visitorInfo.Config "ModuleDefinitionHeader" &&
+                    astNode.IsSuppressed(AnalyserName, "ModuleDefinitionHeader") |> not then
+                    if isPreXmlDocEmpty xmlDoc then
+                        visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationModuleError"))
             | AstNode.ExceptionRepresentation(SynExceptionRepr.ExceptionDefnRepr(_, unionCase, _, xmlDoc, _, range)) ->
                 if configExceptionHeader visitorInfo.Config "ExceptionDefinitionHeader" &&
                     astNode.IsSuppressed(AnalyserName, "ExceptionDefinitionHeader") |> not then

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -28,6 +28,7 @@ module XmlDocumentation =
     open FSharpLint.Framework.Ast
     open FSharpLint.Framework.Configuration
     open FSharpLint.Framework.LoadVisitors
+    open Microsoft.FSharp.Compiler.Ast
 
     [<Literal>]
     let AnalyserName = "XmlDocumentation"
@@ -61,6 +62,12 @@ module XmlDocumentation =
                     let (SynComponentInfo.ComponentInfo(_, _, _, _, xmlDoc, _, _, range)) = coreInfo
                     if isPreXmlDocEmpty xmlDoc then
                         visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationTypeError"))
+            | AstNode.MemberDefinition(SynMemberDefn.Member(synBinding, rng)) ->
+                if configExceptionHeader visitorInfo.Config "MemberDefinitionHeader" &&
+                    astNode.IsSuppressed(AnalyserName, "MemberDefinitionHeader") |> not then
+                    let (SynBinding.Binding(_, _, _, _, _, xmlDoc, _, _, _, _, range, _)) = synBinding
+                    if isPreXmlDocEmpty xmlDoc then
+                        visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationMemberError"))
             | _ -> ()
 
         Continue

--- a/src/FSharpLint.Rules/XmlDocumentation.fs
+++ b/src/FSharpLint.Rules/XmlDocumentation.fs
@@ -78,6 +78,12 @@ module XmlDocumentation =
                     if isPreXmlDocEmpty xmlDoc then
                         visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationEnumError") +
                             " " + id.idText)
+            | AstNode.UnionCase(SynUnionCase.UnionCase(_, id, _, xmlDoc, _, range)) ->
+                if configExceptionHeader visitorInfo.Config "UnionDefinitionHeader" &&
+                    astNode.IsSuppressed(AnalyserName, "UnionDefinitionHeader") |> not then
+                    if isPreXmlDocEmpty xmlDoc then
+                        visitorInfo.PostError range (FSharpLint.Framework.Resources.GetString("RulesXmlDocumentationUnionError") +
+                            " " + id.idText)
             | _ -> ()
 
         Continue

--- a/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
+++ b/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
@@ -101,9 +101,13 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
             |> Seq.isEmpty |> not
 
     member this.ErrorMsg =
-        errorRanges
-            |> Seq.map (fun (r, err) -> (sprintf "(%A %A -> %s)" r.StartRange r.EndRange err ))
-            |> (fun x -> System.String.Join("; ", x))
+        match errorRanges with
+        | xs when xs.Count = 0 -> "No errors"
+        | _ as errRng ->
+            errorRanges
+                |> Seq.map (fun (r, err) -> (sprintf "((%i, %i) - (%i, %i) -> %s)"
+                    r.StartRange.StartLine r.StartColumn r.EndRange.EndLine r.EndRange.EndColumn err ))
+                |> (fun x -> System.String.Join("; ", x))
 
     member this.ErrorWithMessageExistsAt(message, startLine, startColumn) =
         this.ErrorsAt(startLine, startColumn)

--- a/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
+++ b/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
@@ -91,6 +91,11 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
         errorRanges
             |> Seq.exists (fun (r, _) -> r.StartLine = startLine)
 
+    member this.NoErrorExistsOnLine(startLine) =
+        errorRanges
+            |> Seq.exists (fun (r, _) -> r.StartLine = startLine)
+            |> not
+
     // prevent tests from passing if errors exist, just not on the line being checked
     member this.NoErrorsExist =
         errorRanges

--- a/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
+++ b/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
@@ -29,12 +29,12 @@ let emptyConfig =
         UseTypeChecker = false
         IgnoreFiles = { Files = []; Update = IgnoreFiles.IgnoreFilesUpdate.Add }
         Analysers =
-            Map.ofList 
-                [ 
-                    ("", { 
+            Map.ofList
+                [
+                    ("", {
                         Rules = Map.ofList [ ("", { Settings = Map.ofList [ ("", Enabled(true)) ] }) ]
-                        Settings = Map.ofList [] 
-                    }) 
+                        Settings = Map.ofList []
+                    })
                 ]
     }
 
@@ -45,7 +45,7 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
     let postError (range:range) error =
         errorRanges.Add(range, error)
 
-    let config = 
+    let config =
         match analysers with
             | Some(analysers) -> 
                 { 
@@ -74,7 +74,7 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
             | Ast(visitor) ->
                 let parseInfo = { parseInput checkInput input with CheckFiles = checkInput }
                 parse (fun _ -> false) parseInfo [visitor visitorInfo] |> ignore
-            | PlainText(visitor) -> 
+            | PlainText(visitor) ->
                 let parseInfo = parseInput checkInput input
                 let suppressedMessages = getSuppressMessageAttributesFromAst parseInfo.Ast
                 visitor visitorInfo { File = ""; Input = input; SuppressedMessages = suppressedMessages }
@@ -91,10 +91,15 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
         errorRanges
             |> Seq.exists (fun (r, _) -> r.StartLine = startLine)
 
+    // prevent tests from passing if errors exist, just not on the line being checked
+    member this.NoErrorsExist =
+        errorRanges
+            |> Seq.isEmpty
+
     member this.ErrorWithMessageExistsAt(message, startLine, startColumn) =
         this.ErrorsAt(startLine, startColumn)
             |> Seq.exists (fun (_, e) -> e = message)
 
     [<SetUp>]
-    member this.SetUp() = 
+    member this.SetUp() =
         errorRanges.Clear()

--- a/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
+++ b/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
@@ -96,6 +96,15 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
         errorRanges
             |> Seq.isEmpty
 
+    member this.ErrorsExist =
+        errorRanges
+            |> Seq.isEmpty |> not
+
+    member this.ErrorMsg =
+        errorRanges
+            |> Seq.map (fun (r, err) -> (sprintf "(%A %A -> %s)" r.StartRange r.EndRange err ))
+            |> (fun x -> System.String.Join("; ", x))
+
     member this.ErrorWithMessageExistsAt(message, startLine, startColumn) =
         this.ErrorsAt(startLine, startColumn)
             |> Seq.exists (fun (_, e) -> e = message)

--- a/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
+++ b/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
@@ -23,63 +23,27 @@ open FSharpLint.Rules.XmlDocumentation
 open FSharpLint.Framework.Configuration
 open FSharpLint.Framework.LoadVisitors
 
+/// set all XmlDocumentation rules to be disabled, except the one under test
 let config name =
     Map.ofList
         [
             (AnalyserName,
                 {
-                    Rules = Map.ofList
-                        [
-                            ("ModuleDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("ModuleDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("ExceptionDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("ExceptionDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("TypeDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("TypeDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("MemberDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("MemberDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("EnumDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("EnumDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("UnionDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("UnionDefinitionHeader" = name))
-                                        ]
-                                });
-                            ("RecordDefinitionHeader",
-                                {
-                                    Settings = Map.ofList
-                                        [
-                                            ("Enabled", Enabled("RecordDefinitionHeader" = name))
-                                        ]
-                                });
-                        ]
+                    Rules = ["ModuleDefinitionHeader";
+                             "ExceptionDefinitionHeader"
+                             "TypeDefinitionHeader";
+                             "MemberDefinitionHeader";
+                             "EnumDefinitionHeader";
+                             "UnionDefinitionHeader";
+                             "RecordDefinitionHeader"]
+                             |> List.map (fun ruleName ->
+                                 (ruleName,
+                                    {Rule.Settings = Map.ofList
+                                            [
+                                                ("Enabled", Enabled(ruleName = name))
+                                            ]
+                                    }))
+                             |> Map.ofList
                     Settings = Map.ofList []
                 })
             ]

--- a/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
+++ b/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
@@ -35,7 +35,8 @@ let config name =
                              "MemberDefinitionHeader";
                              "EnumDefinitionHeader";
                              "UnionDefinitionHeader";
-                             "RecordDefinitionHeader"]
+                             "RecordDefinitionHeader";
+                             "AutoPropertyDefinitionHeader"]
                              |> List.map (fun ruleName ->
                                  (ruleName,
                                     {Rule.Settings = Map.ofList
@@ -693,6 +694,104 @@ type GeoCoord = {
     // this is longitude
     long: float
     }
+        """
+
+        Assert.IsTrue(this.ErrorsExist)
+        Assert.IsTrue(this.ErrorExistsOnLine(6), this.ErrorMsg)
+
+[<TestFixture>]
+type TestNameConventionRulesAutoProperty() =
+    inherit TestRuleBase.TestRuleBase(Ast(visitor), config "AutoPropertyDefinitionHeader")
+
+    [<Test>]
+    member this.AutoPropertyNoComment() =
+        this.Parse """
+type GeoCoord() =
+    // this is latitude
+    member val Lat = 0 with get, set
+    // this is longitude
+    member val Long = 0 with get, set
+        """
+
+        Assert.IsTrue(this.ErrorsExist)
+        Assert.IsTrue(this.ErrorExistsOnLine(4), this.ErrorMsg)
+        Assert.IsTrue(this.ErrorExistsOnLine(6), this.ErrorMsg)
+
+    [<Test>]
+    member this.AutoPropertyWithDoubleDashComment() =
+        this.Parse """
+type GeoCoord() =
+    // this is latitude
+    member val Lat = 0 with get, set
+    // this is longitude
+    member val Long = 0 with get, set
+        """
+
+        Assert.IsTrue(this.ErrorsExist)
+        Assert.IsTrue(this.ErrorExistsOnLine(4), this.ErrorMsg)
+        Assert.IsTrue(this.ErrorExistsOnLine(6), this.ErrorMsg)
+
+    [<Test>]
+    member this.AutoPropertyWithDoubleDashCommentSuppressed() =
+        this.Parse """
+[<System.Diagnostics.CodeAnalysis.SuppressMessage("XmlDocumentation", "AutoPropertyDefinitionHeader")>]
+type GeoCoord() =
+    // this is latitude
+    member val Lat = 0 with get, set
+    // this is longitude
+    member val Long = 0 with get, set
+        """
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.AutoPropertyWithEmptyXmlComment() =
+        this.Parse ("""
+type GeoCoord() =
+    ///
+    member val Lat = 0 with get, set
+    ///
+    member val Long = 0 with get, set
+        """)
+
+        Assert.IsTrue(this.ErrorsExist)
+        Assert.IsTrue(this.ErrorExistsOnLine(4), this.ErrorMsg)
+        Assert.IsTrue(this.ErrorExistsOnLine(6), this.ErrorMsg)
+
+    [<Test>]
+    member this.AutoPropertyWithMultilineComment() =
+        this.Parse """
+type GeoCoord() =
+    (* this is latitude *)
+    member val Lat = 0 with get, set
+    (* this is longitude *)
+    member val Long = 0 with get, set
+        """
+
+        Assert.IsTrue(this.ErrorsExist)
+        Assert.IsTrue(this.ErrorExistsOnLine(4), this.ErrorMsg)
+        Assert.IsTrue(this.ErrorExistsOnLine(6), this.ErrorMsg)
+
+    [<Test>]
+    member this.AutoPropertyWithXmlComment() =
+        this.Parse """
+type GeoCoord() =
+    /// this is latitude
+    member val Lat = 0 with get, set
+    /// this is longitude
+    member val Long = 0 with get, set
+        """
+
+        Assert.IsTrue(this.NoErrorsExist, this.ErrorMsg)
+
+    [<Test>]
+    member this.AutoPropertyWithAMissingXmlComment() =
+        this.Parse """
+type GeoCoord() =
+    /// this is latitude
+    member val Lat = 0 with get, set
+    // this is longitude
+    member val Long = 0 with get, set
         """
 
         Assert.IsTrue(this.ErrorsExist)

--- a/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
+++ b/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
@@ -23,31 +23,39 @@ open FSharpLint.Rules.XmlDocumentation
 open FSharpLint.Framework.Configuration
 open FSharpLint.Framework.LoadVisitors
 
-let config = 
-    Map.ofList 
-        [ 
-            (AnalyserName, 
-                { 
-                    Rules = Map.ofList 
-                        [ 
-                            ("ExceptionDefinitionHeader", 
-                                { 
-                                    Settings = Map.ofList 
-                                        [ 
-                                            ("Enabled", Enabled(true)) 
-                                        ] 
-                                }) 
+let config =
+    Map.ofList
+        [
+            (AnalyserName,
+                {
+                    Rules = Map.ofList
+                        [
+                            ("ExceptionDefinitionHeader",
+                                {
+                                    Settings = Map.ofList
+                                        [
+                                            ("Enabled", Enabled(true))
+                                        ]
+                                });
+                            ("TypeDefinitionHeader",
+                                {
+                                    Settings = Map.ofList
+                                        [
+                                            ("Enabled", Enabled(true))
+                                        ]
+                                })
                         ]
                     Settings = Map.ofList []
                 })
             ]
 
 [<TestFixture>]
+[<Category("InProgress")>]
 type TestNameConventionRules() =
     inherit TestRuleBase.TestRuleBase(Ast(visitor), config)
 
     [<Test>]
-    member this.ExceptionWithDoubleDashComment() = 
+    member this.ExceptionWithDoubleDashComment() =
         this.Parse """
 module Program
 
@@ -57,7 +65,7 @@ exception SomeException of string"""
         Assert.IsTrue(this.ErrorExistsAt(5, 0))
 
     [<Test>]
-    member this.ExceptionWithDoubleDashCommentSuppressed() = 
+    member this.ExceptionWithDoubleDashCommentSuppressed() =
         this.Parse """
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("XmlDocumentation", "ExceptionDefinitionHeader")>]
 module Program
@@ -65,10 +73,10 @@ module Program
 // Some exception.
 exception SomeException of string"""
 
-        Assert.IsFalse(this.ErrorExistsOnLine(6))
+        Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.ExceptionWithMultilineComment() = 
+    member this.ExceptionWithMultilineComment() =
         this.Parse """
 module Program
 
@@ -78,20 +86,93 @@ exception SomeException of string"""
         Assert.IsTrue(this.ErrorExistsAt(5, 0))
 
     [<Test>]
-    member this.ExceptionWithXmlComment() = 
+    member this.ExceptionWithXmlComment() =
         this.Parse """
 module Program
 
 /// Some exception.
 exception SomeException of string"""
 
-        Assert.IsFalse(this.ErrorExistsAt(5, 0))
+        Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.ExceptionNoComment() = 
+    member this.ExceptionNoComment() =
         this.Parse """
 module Program
 
 exception SomeException of string"""
 
         Assert.IsTrue(this.ErrorExistsAt(4, 0))
+
+    [<Test>]
+    member this.ExceptionWithEmptyXmlComment() =
+        this.Parse """
+module Program
+///
+exception SomeException of string"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 0))
+
+
+    [<Test>]
+    member this.TypeNoComment() =
+        this.Parse """
+
+type IsAType =
+    member this.Test = true
+        """
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 5))
+
+    [<Test>]
+    member this.TypeWithDoubleDashComment() =
+        this.Parse """
+// this is a type
+type IsAType =
+    member this.Test = true
+        """
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 5))
+
+    [<Test>]
+    member this.TypeWithDoubleDashCommentSuppressed() =
+        this.Parse """
+[<System.Diagnostics.CodeAnalysis.SuppressMessage("XmlDocumentation", "TypeDefinitionHeader")>]
+// this is a type
+type IsAType =
+    member this.Test = true
+        """
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.TypeWithWhitespaceXmlComment() =
+        this.Parse ("""
+/// """ + "\t" + """
+type IsAType =
+    member this.Test = true
+        """)
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 5))
+
+    [<Test>]
+    member this.TypeWithMultilineComment() =
+        this.Parse """
+(* This is a type *)
+type IsAType =
+    member this.Test = true
+        """
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 5))
+
+    [<Test>]
+    member this.TypeWithXmlComment() =
+        this.Parse """
+/// This is a type
+///
+/// third line is still ok
+type IsAType =
+    member this.Test = true
+        """
+
+        Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
+++ b/tests/FSharpLint.Rules.Tests/TestXmlDocumentationRules.fs
@@ -23,7 +23,7 @@ open FSharpLint.Rules.XmlDocumentation
 open FSharpLint.Framework.Configuration
 open FSharpLint.Framework.LoadVisitors
 
-/// set all XmlDocumentation rules to be disabled, except the one under test
+/// set all XmlDocumentation rules to be disabled, except the rule under test
 let config name =
     Map.ofList
         [


### PR DESCRIPTION
PR for #11.

The rules will apply in all Access cases; Public, Internal, Private. If we want to ignore one or more (maybe Private), it should not be too difficult.

The rules will trigger if there is XmlDoc that only contains whitespace.

* [x] Module comment
* [x] Function (not inside of a binding expression) comment
* [x] Member comment
  * [x] Method
  * [x] AutoProperty
  * [x] Let (not nested)
* [x] Type comment
* [x] Enum case comment
* [x] Union case comment
* [x] Record field comment