### PR TITLE
fix for #148

### DIFF
--- a/src/FSharpLint.Application/Lint.fs
+++ b/src/FSharpLint.Application/Lint.fs
@@ -206,12 +206,14 @@ module Lint =
                         if parsedFileInfo.PlainText.Contains("SuppressMessage") then
                             Ast.getSuppressMessageAttributesFromAst parsedFileInfo.Ast
                         else []
+                    let stringLiterals = Ast.getStringLiteralsFromAst parsedFileInfo.Ast
 
                     for visitor in LoadPlugins.plainTextVisitors lintInfo.RulePlugins visitorInfo do
                         visitor 
                             { Input = parsedFileInfo.PlainText
                               File = parsedFileInfo.File
-                              SuppressedMessages = suppressMessageAttributes }
+                              SuppressedMessages = suppressMessageAttributes
+                              StringLiterals = stringLiterals }
                 }
 
             let visitAst = async {

--- a/src/FSharpLint.Framework/LoadVisitors.fs
+++ b/src/FSharpLint.Framework/LoadVisitors.fs
@@ -37,6 +37,7 @@ module LoadVisitors =
             File: string
             Input: string
             SuppressedMessages: (Ast.SuppressedMessage * range) list
+            StringLiterals: (string * range) list
         }
 
         with

--- a/src/FSharpLint.Rules/Typography.fs
+++ b/src/FSharpLint.Rules/Typography.fs
@@ -155,7 +155,15 @@ module Typography =
 
                 if indexOfTab >= 0 then
                     let range = mkRange (mkPos lineNumber indexOfTab) (mkPos lineNumber (indexOfTab + 1))
-                    if plaintextVisitorInfo.IsSuppressed(range, AnalyserName, "NoTabCharacters") |> not then
+                    let isSuppressed range =
+                        plaintextVisitorInfo.IsSuppressed(range, AnalyserName, "NoTabCharacters")
+                    let rangeContainsOtherRange (containingRange:range) (range:range) =
+                        posGeq range.Start containingRange.Start &&
+                        posGeq containingRange.End range.End
+                    let isInStringLiteral range =
+                        plaintextVisitorInfo.StringLiterals
+                        |> Seq.exists (fun (_, literalRange) -> rangeContainsOtherRange literalRange range)
+                    if (isSuppressed range || isInStringLiteral range) |> not then
                         visitorInfo.PostError range (Resources.GetString("RulesTypographyTabCharacterError"))
 
     let analyseLine (visitorInfo:VisitorInfo) mkRange suppressMessageAttributes lineNumber (line:string) = 

--- a/tests/FSharpLint.Framework.Tests/TestAst.fs
+++ b/tests/FSharpLint.Framework.Tests/TestAst.fs
@@ -236,3 +236,28 @@ let dog = ()"""
 
             lintFile (fun _ -> false) result [visitWholeTree]
         | _ -> failwith "Failed to parse input."
+
+    [<Test>]
+    member __.GetStringLiteralsFromAst() =
+        let input =
+            """
+module Foo =
+    let value = "value"
+
+let dog = "dog"
+let escaped = @"test" """
+
+        let stubConfig =
+            {
+                UseTypeChecker = Some(false)
+                IgnoreFiles =
+                    Some({ Update = IgnoreFiles.Overwrite
+                           Files = []
+                           Content = "" })
+                Analysers = Map.ofList []
+            }
+
+        match parseSource input stubConfig (FSharpChecker.Create()) with
+            | ParseFileResult.Success(result) ->
+                Assert.AreEqual(3, getStringLiteralsFromAst result.Ast |> List.length)
+            | _ -> failwith "Failed to parse input."

--- a/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
+++ b/tests/FSharpLint.Rules.Tests/TestRuleBase.fs
@@ -71,7 +71,13 @@ type TestRuleBase(analyser:VisitorType, ?analysers) =
             lintFile (fun _ -> false) parseInfo [visitor visitorInfo]
         | Success(parseInfo), PlainText(visitor) -> 
             let suppressedMessages = getSuppressMessageAttributesFromAst parseInfo.Ast
-            visitor visitorInfo { File = ""; Input = input; SuppressedMessages = suppressedMessages }
+            let stringLiterals = getStringLiteralsFromAst parseInfo.Ast
+            visitor
+                visitorInfo
+                { File = ""
+                  Input = input
+                  SuppressedMessages = suppressedMessages
+                  StringLiterals = stringLiterals }
         | _ -> failwith "Failed to parse input."
 
     member __.ErrorExistsAt(startLine, startColumn) =

--- a/tests/FSharpLint.Rules.Tests/TestTypographyRules.fs
+++ b/tests/FSharpLint.Rules.Tests/TestTypographyRules.fs
@@ -206,7 +206,19 @@ type TestNestedStatements() =
         Assert.IsFalse(this.ErrorExistsAt(3, 8))
 
     [<Test>]
-    member this.NewLineOnEndOfFile() = 
+    member this.``Tab character in literal strings are not reported``() =
+        this.Parse (sprintf """
+            let a = @"a%sb"
+            let b = %s
+            a%sb
+            %s
+            """ "\t" "\"\"\"" "\t" "\"\"\"")
+
+        Assert.IsFalse(this.ErrorExistsAt(2, 23))
+        Assert.IsFalse(this.ErrorExistsAt(4, 13))
+
+    [<Test>]
+    member this.NewLineOnEndOfFile() =
         this.Parse ("let dog = 9" + System.Environment.NewLine)
 
         Assert.IsTrue(this.ErrorExistsAt(2, 0))


### PR DESCRIPTION
I've started to work on a fix for #148.

Currently the typography rules, and no tab rule especially, are implemented with the `PlainTextVisitor`. This visitor do not have sufficient information about the AST to be able to decide whether it's a literal string or not.
Any pointers to how the implementation should be done are welcome.