### PR TITLE
Disable TrailingNewLineInFile check by default

### DIFF
--- a/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint
@@ -260,7 +260,7 @@
         </NoTabCharacters>
 
         <TrailingNewLineInFile>
-          <Enabled>true</Enabled>
+          <Enabled>false</Enabled>
         </TrailingNewLineInFile>
 
         <TrailingWhitespaceOnLine>


### PR DESCRIPTION
By Unix convention, source code (and text files in general) should end with a single newline character; see http://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline and http://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file for two examples. Linters for most languages will warn if a source file does *not* end with a newline on the final line (e.g., http://pylint-messages.wikidot.com/messages:c0304 for PyLint), and the C standard actually *requires* a newline at the end of the final line (http://gcc.gnu.org/ml/gcc/2003-11/msg01568.html). Because of this, most programmers' editors ensure that a file always ends with a newline even if the user hasn't explicitly typed one. (Visual Studio is a glaring exception, and this annoys many people: https://visualstudio.uservoice.com/forums/293070-visual-studio-code/suggestions/8298222-add-new-line-at-the-end-file-on-save for example).

Given that this is a widespread standard, we should not treat F# differently. Multiple newlines at the end of the file may be an error we should check for, but a single newline at the end of the file should not be considered an error.