### PR TITLE
Support international chars

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+##### 0.4.9 - October 8 2016
+
+* Fixed bug: https://github.com/fsprojects/FSharpLint/issues/184
+
+##### 0.4.8 - September 13 2016
+
+* Updated wording of warnings.
+* Disabled `RecordFieldNamesMustBePascalCase` naming rule by default.
+
 ##### 0.4.7-beta - September 9 2016
 
 * Included FSharp.Core.sigdata and FSharp.Core.optdata in the FSharpLint.MSBuild package.

--- a/build.fsx
+++ b/build.fsx
@@ -28,7 +28,7 @@ let summaryApi = "FSharpLint Api (Lint tool for F#)."
 // List of author names (for NuGet package)
 let authors = [ "Matthew Mcveigh" ]
 
-let version = "0.4.7-beta"
+let version = "0.4.9"
 
 // File system information 
 // (<solutionFile>.sln is built during the building process)

--- a/src/FSharpLint.Core/Rules/NameConventions.fs
+++ b/src/FSharpLint.Core/Rules/NameConventions.fs
@@ -79,11 +79,11 @@ module NameConventions =
     [<Literal>]
     let AnalyserName = "NameConventions"
 
-    let private pascalCaseRegex = Regex(@"^[A-Z]([a-z]|[A-Z]|\d)*", RegexOptions.Compiled)
+    let private pascalCaseRegex = Regex(@"^(\p{Lu}|\p{Lt})(\p{L}|\p{N})*", RegexOptions.Compiled)
 
     let isPascalCase (identifier:string) = pascalCaseRegex.IsMatch(identifier)
 
-    let private camelCaseRegex = Regex(@"^_*[a-z]([a-z]|[A-Z]|\d)*", RegexOptions.Compiled)
+    let private camelCaseRegex = Regex(@"^_*(\p{Ll}|\p{Lo}|\p{Lm})(\p{L}|\p{N})*", RegexOptions.Compiled)
 
     let isCamelCase (identifier:string) = camelCaseRegex.IsMatch(identifier)
 

--- a/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
@@ -1210,3 +1210,24 @@ type Foo = Foo of bool
 for Foo(foo) in [Foo(true)] do ()"""
 
         Assert.IsFalse(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Upper case international characters recognised by PascalCase rule``() =
+        this.Parse """
+module Program
+
+type Ścieżka = Ścieżka of string
+        """
+
+        Assert.IsFalse(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Lower case international characters recognised by camelCase rule``() =
+        this.Parse """
+module Program
+
+let foo () =
+    let żcieżka = 0
+        """
+
+        Assert.IsFalse(this.ErrorsExist)


### PR DESCRIPTION
Fix for https://github.com/fsprojects/FSharpLint/issues/184

Updates existing regex, replacing ascii char ranges with unicode character classes