### PR TITLE
Backticked identifiers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.4.12 - November 16 2016
+
+* Fixed bug: https://github.com/fsprojects/FSharpLint/issues/191
+
 ##### 0.4.11 - November 10 2016
 
 * Bug fixed by [@rexcfnghk](https://github.com/rexcfnghk): https://github.com/fsprojects/FSharpLint/issues/189

--- a/build.fsx
+++ b/build.fsx
@@ -28,7 +28,7 @@ let summaryApi = "FSharpLint Api (Lint tool for F#)."
 // List of author names (for NuGet package)
 let authors = [ "Matthew Mcveigh" ]
 
-let version = "0.4.11"
+let version = "0.4.12"
 
 // File system information 
 // (<solutionFile>.sln is built during the building process)

--- a/src/FSharpLint.Console/AssemblyInfo.fs
+++ b/src/FSharpLint.Console/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharpLint")>]
 [<assembly: AssemblyProductAttribute("FSharpLint")>]
 [<assembly: AssemblyDescriptionAttribute("Lint tool for F#.")>]
-[<assembly: AssemblyVersionAttribute("0.4.11")>]
-[<assembly: AssemblyFileVersionAttribute("0.4.11")>]
+[<assembly: AssemblyVersionAttribute("0.4.12")>]
+[<assembly: AssemblyFileVersionAttribute("0.4.12")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharpLint"
     let [<Literal>] AssemblyProduct = "FSharpLint"
     let [<Literal>] AssemblyDescription = "Lint tool for F#."
-    let [<Literal>] AssemblyVersion = "0.4.11"
-    let [<Literal>] AssemblyFileVersion = "0.4.11"
+    let [<Literal>] AssemblyVersion = "0.4.12"
+    let [<Literal>] AssemblyFileVersion = "0.4.12"

--- a/src/FSharpLint.Core/AssemblyInfo.fs
+++ b/src/FSharpLint.Core/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharpLint")>]
 [<assembly: AssemblyProductAttribute("FSharpLint")>]
 [<assembly: AssemblyDescriptionAttribute("Lint tool for F#.")>]
-[<assembly: AssemblyVersionAttribute("0.4.11")>]
-[<assembly: AssemblyFileVersionAttribute("0.4.11")>]
+[<assembly: AssemblyVersionAttribute("0.4.12")>]
+[<assembly: AssemblyFileVersionAttribute("0.4.12")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharpLint"
     let [<Literal>] AssemblyProduct = "FSharpLint"
     let [<Literal>] AssemblyDescription = "Lint tool for F#."
-    let [<Literal>] AssemblyVersion = "0.4.11"
-    let [<Literal>] AssemblyFileVersion = "0.4.11"
+    let [<Literal>] AssemblyVersion = "0.4.12"
+    let [<Literal>] AssemblyFileVersion = "0.4.12"

--- a/src/FSharpLint.Fake/AssemblyInfo.fs
+++ b/src/FSharpLint.Fake/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharpLint")>]
 [<assembly: AssemblyProductAttribute("FSharpLint")>]
 [<assembly: AssemblyDescriptionAttribute("Lint tool for F#.")>]
-[<assembly: AssemblyVersionAttribute("0.4.11")>]
-[<assembly: AssemblyFileVersionAttribute("0.4.11")>]
+[<assembly: AssemblyVersionAttribute("0.4.12")>]
+[<assembly: AssemblyFileVersionAttribute("0.4.12")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharpLint"
     let [<Literal>] AssemblyProduct = "FSharpLint"
     let [<Literal>] AssemblyDescription = "Lint tool for F#."
-    let [<Literal>] AssemblyVersion = "0.4.11"
-    let [<Literal>] AssemblyFileVersion = "0.4.11"
+    let [<Literal>] AssemblyVersion = "0.4.12"
+    let [<Literal>] AssemblyFileVersion = "0.4.12"

--- a/src/FSharpLint.MSBuild/AssemblyInfo.fs
+++ b/src/FSharpLint.MSBuild/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharpLint")>]
 [<assembly: AssemblyProductAttribute("FSharpLint")>]
 [<assembly: AssemblyDescriptionAttribute("Lint tool for F#.")>]
-[<assembly: AssemblyVersionAttribute("0.4.11")>]
-[<assembly: AssemblyFileVersionAttribute("0.4.11")>]
+[<assembly: AssemblyVersionAttribute("0.4.12")>]
+[<assembly: AssemblyFileVersionAttribute("0.4.12")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharpLint"
     let [<Literal>] AssemblyProduct = "FSharpLint"
     let [<Literal>] AssemblyDescription = "Lint tool for F#."
-    let [<Literal>] AssemblyVersion = "0.4.11"
-    let [<Literal>] AssemblyFileVersion = "0.4.11"
+    let [<Literal>] AssemblyVersion = "0.4.12"
+    let [<Literal>] AssemblyFileVersion = "0.4.12"

--- a/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
@@ -1228,6 +1228,20 @@ module Program
 
 let foo () =
     let żcieżka = 0
+    ()
+        """
+
+        Assert.IsFalse(this.ErrorsExist)
+
+    /// Regression test for: https://github.com/fsprojects/FSharpLint/issues/191
+    [<Test>]
+    member this.``Backticked let binding identifier not checked by name convention rules``() =
+        this.Parse """
+module Program
+
+let foo () =
+    let ``¯\_(ツ)_/¯`` = ignore
+    ()
         """
 
         Assert.IsFalse(this.ErrorsExist)


### PR DESCRIPTION
Not the greatest solution here (but works), information on backticks doesn't appear to be in the AST. This fix will need to be improved to look at the source to find the backticks, rather than only comparing the length of the source ident vs the length of the AST ident