### PR TITLE
Add a hint for Array.append

### DIFF
--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -125,6 +125,8 @@
           null = x ===> m"Consider using pattern matching, or if you're using F# 4 then `isNull`"
           x <> null ===> m"Consider using pattern matching, or if you're using F# 4 then `isNull`"
           null <> x ===> m"Consider using pattern matching, or if you're using F# 4 then `isNull`"
+
+          Array.append a (Array.append b c) ===> Array.concat [|a; b; c|]
         ]]>
       </Hints>
       <Enabled>true</Enabled>


### PR DESCRIPTION
Array.append a (Array.append b c) ===> Array.concat [|a; b; c|]

See https://github.com/Microsoft/visualfsharp/pull/2296

Not sure it matters for List and Seq so I left those out, but nested Array.append are generating wasteful intermediary arrays, that can be avoided with Array.concat.