### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/content/Binding.md
+++ b/docs/content/Binding.md
@@ -1,81 +1,81 @@
-#Binding
+# Binding
 
 Set of rules that analyse possible mistakes when binding values.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####FavourIgnoreOverLetWild
+#### FavourIgnoreOverLetWild
 
-#####Cause
+##### Cause
 
 A value is binded to a wildcard e.g. `let _ = Console.ReadLine()`
 
-#####Rationale
+##### Rationale
 
 Using the ignore function makes it clear what is intended to happen, rather than something that may be a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Pipe the value into the ignore function e.g. `Console.ReadLine() |> ignore`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####UselessBinding
+#### UselessBinding
 
-#####Cause
+##### Cause
 
 An identifier is binded to itself e.g. `let x = x`
 
-#####Rationale
+##### Rationale
 
 Pointless statement likely to be an error.
 
-#####How To Fix
+##### How To Fix
 
 Remove the binding.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####WildcardNamedWithAsPattern
+#### WildcardNamedWithAsPattern
 
-#####Cause
+##### Cause
 
 A wildcard is given a name using the as pattern e.g. `match something with | _ as x -> x + y`
 
-#####Rationale
+##### Rationale
 
 The wildcard and as pattern can be replaced with the identifier the value is to be bound to.
 
-#####How To Fix
+##### How To Fix
 
 Replace the wildcard with the identifier the wildcard is currently being bound to, e.g. change `match something with | _ as x -> x + y` to `match something with | x -> x + y`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####TupleOfWildcards
+#### TupleOfWildcards
 
-#####Cause
+##### Cause
 
 A constructor in a pattern has arguments that consist entirely of wildcards e.g. `SynPat.Paren(_, _)`
 
-#####Rationale
+##### Rationale
 
 The tuple of wildcards can be replaced with a single wildcard.
 
-#####How To Fix
+##### How To Fix
 
 Replace the tuple with a single wildcard e.g. the example in the cause could be turned into `SynPat.Paren(_)`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)

--- a/docs/content/FunctionReimplementation.md
+++ b/docs/content/FunctionReimplementation.md
@@ -1,56 +1,56 @@
-#FunctionReimplementation
+# FunctionReimplementation
 
 Set of rules that highlight lambda functions that can removed through eta reduction.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####ReimplementsFunction
+#### ReimplementsFunction
 
-#####Cause
+##### Cause
 
 A lambda function does nothing other than call an existing function, two examples below:
 
 `fun x y -> x + y`
 `fun x y -> foo x y`
 
-#####Rationale
+##### Rationale
 
 The lambda functions are redundant.
 
-#####How To Fix
+##### How To Fix
 
 Replace the lambda with the function that is being called.
 
 `fun x y -> x + y` is the same as `(+)`
 `fun x y -> foo x y` is the same as `foo`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####CanBeReplacedWithComposition
+#### CanBeReplacedWithComposition
 
-#####Cause
+##### Cause
 
 A lambda function applies a single argument to a chain of function calls, two examples below:
 
 `fun x -> not(isValid(x))`
 `fun x -> x |> isValid |> not`
 
-#####Rationale
+##### Rationale
 
 The lambda functions are redundant.
 
-#####How To Fix
+##### How To Fix
 
 Replace the lambda with function composition:
 
 `fun x -> not(isValid(x))` and `fun x -> x |> isValid |> not` are the same as `isValid >> not`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)

--- a/docs/content/Hints.md
+++ b/docs/content/Hints.md
@@ -1,14 +1,14 @@
-#Hints
+# Hints
 
-###Introduction
+### Introduction
 
 The Hints analyser is inspired by [HLint](https://github.com/ndmitchell/hlint). The hints let users easily write their own rules which are matched against linted code and when matched produce a suggestion that the user provides as part of the hint.
 
 Every hint is formed of two parts: the match and the suggestion. Both the match and the suggestion are parsed the same way into ASTs, but they have two different purposes; the match AST is analysed against the code being linted looking for any expressions in the code that match the AST, and if there is a match then the suggestion AST is used to display a suggestion on how the code can be refactored.
 
-###Matching
+### Matching
 
-#####Match Any Expression
+##### Match Any Expression
 
 Any F# expression can be matched by a variable or wildcard.
 
@@ -30,7 +30,7 @@ We can use variables here, the expression `(4 + 4)` can be matched by a variable
     [lang=hint]
     not (a >= b) ===> a <  b
 
-#####Match An Identifier
+##### Match An Identifier
 
 Identifiers in F# code can be matched by using the same identifier in the hint. It's important to note that since single characters are used to represent variables in hints the identifier must be at least 2 characters long.
 
@@ -41,7 +41,7 @@ For example the following rule uses identifiers:
 
 `List.fold` in the hint will match the same identifier in the code. So if `List.fold` is found anywhere in the F# code being analysed with `(+)` and `0` applied to it then the rule will be matched.
 
-#####Match Literal Constants
+##### Match Literal Constants
 
 Literal constants can be used to match literal constants in the code, the constants in hints are the same format as constants in F#, so for example if you wanted to match `0x4b` you could use `0x4b` in the hint.
 
@@ -52,7 +52,7 @@ Example:
 	
 In the example above the boolean literal `true` is used to match any F# code where `true` is applied to the `not` identifier.
 
-#####Match Function Application and Operators
+##### Match Function Application and Operators
 
 Matching function application, prefix operators, and infix operators in hints are all done in the same way as how you'd write it in F# e.g.
 
@@ -65,7 +65,7 @@ The first rule above matches `true` (boolean literal) applied to the function `n
 	
 Read the below section titled "Order Of Operations" for specifying the order of application in a hint.
 
-#####Match Lambda Functions
+##### Match Lambda Functions
 
 Lambda functions can be matched using the syntax `fun args -> ()` e.g. `fun x y -> x + y`.
 
@@ -78,7 +78,7 @@ For example:
 	
 The above hint will match a lambda that has a single argument which is an identifier and returns that identifier. `fun val -> val` would be matched, whereas `fun val -> ()` would not be matched - to match this you could use the hint: `fun _ -> ()`.
 
-#####Order Of Operations
+##### Order Of Operations
 
 Generic order of operations can be specified using parentheses. They're described as 'generic' because using parentheses in a hint will also take into account the following operators: `|>`, `||>`, `|||>`, `<|`, `<||`, and `<|||` which are often used to specificy the order of function application.
 
@@ -93,7 +93,7 @@ In F# several operators are commonly used to show the order of function applicat
 	
 The same code written as a rule `not x |> someFunc` will match the above, but it is matching against the operator so it will not match `someFunc (not x)`. However the rule `someFunc (not x)` will match both.
 
-###EBNF of a Hint
+### EBNF of a Hint
 
 This is incomplete - currently missing a few of the more detailed rules e.g. `uint32` and `infix-operator`, for these I'd recommend looking them up in the EBNF for F# as that's what they will be based upon.
 
@@ -186,7 +186,7 @@ This is incomplete - currently missing a few of the more detailed rules e.g. `ui
 
     hint = match, spaces, "===>", spaces, suggestion;
 
-###Writing Your Own Hints
+### Writing Your Own Hints
 
 Currently to provide your own hints you have to overwrite the default hints with your own using the `Hints `property inside of the `Hints` rule.
 
@@ -208,18 +208,18 @@ For example to make the lint tool run with just the two hints: `not (a =  b) ===
         </Analysers>
     </FSharpLintSettings>
 
-###Flaws
+### Flaws
 
 * `===>` is used to split the hints into parts, a hint cannot match this valid F# operator.
 * Single letter identifiers are used as variables inside a hint, so attempting to match an identifier that is a single letter is not going to work.
 * Operators beginning with `.` e.g. `.*` will have incorrect precedence and as such should not currently be used in hints.
 
-###Future Intentions
+### Future Intentions
 
 * Provide more informative parse errors.
 * Allow for adding your own hints and removing select hints rather than always having to override the default with a set of hints.
 * Provide support for matching literal lists, literal arrays, literal sequences, tuples, methods, if statements, and match statements.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default True)

--- a/docs/content/NameConventions.md
+++ b/docs/content/NameConventions.md
@@ -1,214 +1,214 @@
-#NameConventions
+# NameConventions
 
 Set of rules that analyse the naming of user defined elements within a program. The rules and their errors are based on the [F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####IdentifiersMustNotContainUnderscores
+#### IdentifiersMustNotContainUnderscores
 
-#####Cause
+##### Cause
 
 Any identifier contains an underscore in its name for example: `let goat_machine = 0`
 
-#####Rationale
+##### Rationale
 
 *"Historically, some F# libraries have used underscores in names. However, this is no longer widely accepted, partly because it clashes with .NET naming conventions. That said, some F# programmers use underscores heavily, partly for historical reasons, and tolerance and respect is important. However, be aware that the style is often disliked by others who have a choice about whether to use it."* - [F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
-#####How To Fix
+##### How To Fix
 
 Remove the underscore from the identifier, for the example listed in the cause the fix would be to turn it into: `let goatMachine = 0`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####InterfaceNamesMustBeginWithI
+#### InterfaceNamesMustBeginWithI
 
-#####Cause
+##### Cause
 
 An identifier naming an interface not beginning with the letter `I` e.g. `type Printable = abstract member Print : unit -> unit`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `IEnumerable`
 
-#####How To Fix
+##### How To Fix
 
 Add `I` onto the beginning of the identifier, for the example listed in the cause, the fix would be to turn it into: `type IPrintable = abstract member Print : unit -> unit`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####ExceptionNamesMustEndWithException
+#### ExceptionNamesMustEndWithException
 
-#####Cause
+##### Cause
 
 An identifier naming an exception not ending with the word `Exception` e.g. `exception Read of string`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `NullReferenceException`
 
-#####How To Fix
+##### How To Fix
 
 Add `Exception` onto the end of the identifier, for the example listed in the cause, the fix would be to turn it into: `exception ReadException of string`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####TypeNamesMustBePascalCase
+#### TypeNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The name of a type was not in PascalCase, for example this would fail: `class foo`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `LinkedList<T>`
 
-#####How To Fix
+##### How To Fix
 
 Change the name of the type to PascalCase e.g. `class Foo`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####RecordFieldNamesMustBePascalCase
+#### RecordFieldNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The name of a field in a record was not in PascalCase, for example this would fail: `type Cat = { dog: int }`
 
-#####Rationale
+##### Rationale
 
 Suggested in [F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/). A record field in C# will be a class property so it makes sense to have it be PascalCase as that's the convention for properties in .NET
 
-#####How To Fix
+##### How To Fix
 
 Change the name of the field to PascalCase e.g. `type Cat = { Dog: int }`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####EnumCasesMustBePascalCase
+#### EnumCasesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The name of a case in an enum was not in PascalCase, for example this would fail: `type MyEnum = | enumCase = 1`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `DayOfWeek.Friday`
 
-#####How To Fix
+##### How To Fix
 
 Change the name of the enum case to PascalCase e.g. `type MyEnum = | EnumCase = 1`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####ModuleNamesMustBePascalCase
+#### ModuleNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The name of a module was not in PascalCase, for example this would fail: `module dog`
 
-#####Rationale
+##### Rationale
 
 F# convention. Also from C# an F# module will be represented as a static class, and the .NET convention for type names is PascalCase.
 
-#####How To Fix
+##### How To Fix
 
 Change the name of the module to PascalCase e.g. `module Dog`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####LiteralNamesMustBePascalCase
+#### LiteralNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The literal value was not in PascalCase, for example this would fail: `let [<Literal>] foo = 5`
 
-#####Rationale
+##### Rationale
 
 There's a practical reason here, [you won't be able to pattern match against literals beginning with a lowercase letter](http://msdn.microsoft.com/en-us/library/dd233193.aspx).
 
-#####How To Fix
+##### How To Fix
 
 Change the literal value to PascalCase e.g. `let [<Literal>] Foo = 5`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####NamespaceNamesMustBePascalCase
+#### NamespaceNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The namespace was not in PascalCase, for example this would fail: `namespace matt.dog.cat"`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `System.Collections.Generic`
 
-#####How To Fix
+##### How To Fix
 
 Change the namespace to PascalCase e.g. `namespace Matt.Dog.Cat"`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####MemberNamesMustBePascalCase
+#### MemberNamesMustBePascalCase
 
-#####Cause
+##### Cause
 
 The member was not in PascalCase, for example this would fail: `this.member() = ()`
 
-#####Rationale
+##### Rationale
 
 .NET convention e.g. `this.ToString()`
 
-#####How To Fix
+##### How To Fix
 
 Change the member to PascalCase e.g. `this.Member() = ()`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####ParameterMustBeCamelCase
+#### ParameterMustBeCamelCase
 
-#####Cause
+##### Cause
 
 The parameter in a function or method was not in camelCase, for example this would fail: `let f FooBar = FooBar`
 
-#####Rationale
+##### Rationale
 
 Non public values should be camelCase, see [NonPublicValuesCamelCase](#NonPublicValuesCamelCase).
 
-#####How To Fix
+##### How To Fix
 
 Change the parameter to camelCase e.g. `let f fooBar = fooBar`
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.
 
-####NonPublicValuesCamelCase
+#### NonPublicValuesCamelCase
 
-#####Cause
+##### Cause
 
 A function or value that is not externally accessible's identifier is not in camelCase, for example this would fail: 
 
@@ -216,7 +216,7 @@ A function or value that is not externally accessible's identifier is not in cam
         let Woof = 4 * x
         Woof
 
-#####Rationale
+##### Rationale
 
 *"It is common and accepted F# style to use camelCase for all names bound as local variables or in pattern matches and function definitions. ... It is also common and accepted F# style to use camelCase for locally bound functions"* - [F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
@@ -224,7 +224,7 @@ Rationale for public values being either PascalCase or CamelCase:
 
 *"Do use either PascalCase or camelCase for public functions and values in F# modules. camelCase is generally used for public functions which are designed to be used unqualified (e.g. invalidArg), and for the “standard collection functions” (e.g. List.map). In both these cases, the function names act much like keywords in the language."* - [F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
-#####How To Fix
+##### How To Fix
 
 Change the value's identifier to camelCase e.g.
 
@@ -232,6 +232,6 @@ Change the value's identifier to camelCase e.g.
         let woof = 4 * x
         woof
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule.

--- a/docs/content/NestedStatements.md
+++ b/docs/content/NestedStatements.md
@@ -1,8 +1,8 @@
-#NestedStatements
+# NestedStatements
 
 Single rule that checks code is not more deeply nested than a configurable depth.
 
-#####Cause
+##### Cause
 
 A statement is nested deeper than a configurable depth, for example if `MaxItems` was set to 8 (the default) then the following code would cause an error:
 
@@ -17,11 +17,11 @@ A statement is nested deeper than a configurable depth, for example if `MaxItems
 									if true then		// Depth 8
 										()		// Depth 9!!
 
-#####Rationale
+##### Rationale
 
 When code becomes too deeply nested it becomes more difficult to read and understand, try to refactor nested code out into functions. 
 
-#####How To Fix
+##### How To Fix
 
 Reduce the depth of the deepest statement, e.g. to fix the example in the "Cause" section you'd take out on level of depth:
 
@@ -35,7 +35,7 @@ Reduce the depth of the deepest statement, e.g. to fix the example in the "Cause
 								if true then			// Depth 7
 									()			// Depth 8
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Depth` - An integer property that specifies the max depth of a statement. (Default 8)

--- a/docs/content/NumberOfItems.md
+++ b/docs/content/NumberOfItems.md
@@ -1,91 +1,91 @@
-#NumberOfItems
+# NumberOfItems
 
 Set of rules that analyse the number of items in a segment of code, for example the number of members in a class.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####MaxNumberOfFunctionParameters
+#### MaxNumberOfFunctionParameters
 
-#####Cause
+##### Cause
 
 A function contains more than a configurable number of parameters, for example if `MaxItems` was set to 5 (the default value)
 then the following condition would cause the error: `let findCat one two three four five six = 0`
 
-#####Rationale
+##### Rationale
 
 Too many parameters make the function difficult to use.
 
-#####How To Fix
+##### How To Fix
 
 Reduce the number of function parameters, e.g. to fix the example in the "Cause": `let findCat one two three four five = 0`. A good way to reduce the number of parameters is to group them using records.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `MaxItems` - An integer property that specifies the max number of function parameters. (Default 5)
 
-####MaxNumberOfMembers
+#### MaxNumberOfMembers
 
-#####Cause
+##### Cause
 
 A class contains more than a configurable number of members (`MaxItems`).
 
-#####Rationale
+##### Rationale
 
 The class is likely to be doing too much and violating the single responsibility principle.
 
-#####How To Fix
+##### How To Fix
 
 Reduce the number of members in the class, e.g. extract them out to another class.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `MaxItems` - An integer property that specifies the max number of members in a class. (Default 32)
 
-####MaxNumberOfItemsInTuple
+#### MaxNumberOfItemsInTuple
 
-#####Cause
+##### Cause
 
 A tuple contains more than a configurable number of items, for example if `MaxItems` was set to 4 (the default value)
 then the following statement would cause the error: `let tup = (1, 2, 3, 5, 6)`
 
-#####Rationale
+##### Rationale
 
 Tuple's items are not named, the more items there are the harder it is to work out what each is for.
 
-#####How To Fix
+##### How To Fix
 
 Reduce the number of items in the tuple, ideally replace the tuple with a record.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `MaxItems` - An integer property that specifies the max number of items in a tuple. (Default 4)
 
-####MaxNumberOfBooleanOperatorsInCondition
+#### MaxNumberOfBooleanOperatorsInCondition
 
-#####Cause
+##### Cause
 
 A `while/if/assert/match when` condition contains more than a configurable number of boolean operators, for example if `MaxItems` was set to 4 (the default value)
 then the following condition would cause the error: `if x && y || q || r && t && w then`
 
-#####Rationale
+##### Rationale
 
 Can make the control flow become diffcult to understand.
 
-#####How To Fix
+##### How To Fix
 
 Reduce the number of boolean operators in the `while/if/assert/match when` condition, e.g. a simple way to fix the example in the "Cause" section you could name the expression:
 
     let catIsInBin = x && y || q || r && t && w
     if catIsInBin then
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `MaxItems` - An integer property that specifies the max number of boolean operators in a condition. (Default 4)

--- a/docs/content/RaiseWithTooManyArguments.md
+++ b/docs/content/RaiseWithTooManyArguments.md
@@ -1,117 +1,117 @@
-#RaiseWithTooManyArguments
+# RaiseWithTooManyArguments
 
 `raise` [can be passed more than one argument](http://visualfsharp.codeplex.com/workitem/41), in code this is likely to be a mistake and these rules warn when this occurs.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####RaiseWithSingleArgument
+#### RaiseWithSingleArgument
 
-#####Cause
+##### Cause
 
 `raise` is passed more than one argument e.g. `raise (System.ArgumentException("Divisor cannot be zero.")) 5`
 
-#####Rationale
+##### Rationale
 
 `raise` being passed more than one argument (the exception to be thrown) is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####FailwithWithSingleArgument
+#### FailwithWithSingleArgument
 
-#####Cause
+##### Cause
 
 `failwith` is passed more than one argument e.g. `failwith "Divisor cannot be zero." 5`
 
-#####Rationale
+##### Rationale
 
 `failwith` being passed more than one argument (the error message) is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####NullArgWithSingleArgument
+#### NullArgWithSingleArgument
 
-#####Cause
+##### Cause
 
 `nullArg` is passed more than one argument e.g. `nullArg "Divisor cannot be zero." 5`
 
-#####Rationale
+##### Rationale
 
 `nullArg` being passed more than one argument (the error message) is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####InvalidOpWithSingleArgument
+#### InvalidOpWithSingleArgument
 
-#####Cause
+##### Cause
 
 `invalidOp` is passed more than one argument e.g. `invalidOp "Divisor cannot be zero." 5`
 
-#####Rationale
+##### Rationale
 
 `invalidOp` being passed more than one argument (the error message) is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####FailwithfWithArgumentsMatchingFormatString
+#### FailwithfWithArgumentsMatchingFormatString
 
-#####Cause
+##### Cause
 
 `failwithf` is passed more arguments than the format string (first argument) species e.g. `failwithf "%d" 5 5`
 
-#####Rationale
+##### Rationale
 
 `failwithf` being passed more arguments than the format string (first argument) specifies is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####InvalidArgWithTwoArguments
+#### InvalidArgWithTwoArguments
 
-#####Cause
+##### Cause
 
 `invalidArg` is passed more than two arguments e.g. `invalidArg "month" "Expected value between 1 and 12"`
 
-#####Rationale
+##### Rationale
 
 `invalidArg` being passed more than two arguments is probably a mistake.
 
-#####How To Fix
+##### How To Fix
 
 Remove the extra arguments.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)

--- a/docs/content/SourceLength.md
+++ b/docs/content/SourceLength.md
@@ -1,73 +1,73 @@
-#SourceLength
+# SourceLength
 
 Set of rules that analyse the length of sections of code.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default true)
 
-###Rules
+### Rules
 
-####MaxLinesInFunction
+#### MaxLinesInFunction
 
-#####Cause
+##### Cause
 
 A function is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a function becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Refactor to extract out code into smaller composable functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a function. (Default 70)
 
-####MaxLinesInLambdaFunction
+#### MaxLinesInLambdaFunction
 
-#####Cause
+##### Cause
 
 A lambda function is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 Lambda functions are usually used for single lines of code that aren't worth naming to make code more concise. A large lambda function indicates it should probably be a named function.
 
-#####How To Fix
+##### How To Fix
 
 Consider using a named function rather than a lambda function.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a lambda function. (Default 7)
 
-####MaxLinesInMatchLambdaFunction
+#### MaxLinesInMatchLambdaFunction
 
-#####Cause
+##### Cause
 
 A match function is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a function becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Use active patterns to help reduce the number of matches/extract code out into composable functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a match function. (Default 70)
 
-####MaxLinesInValue
+#### MaxLinesInValue
 
-#####Cause
+##### Cause
 
 A statement binded to a value is made up of more than a configurable number of lines. 
 For example the following would break the rule when the maximum number of lines is set to 4:
@@ -79,167 +79,167 @@ For example the following would break the rule when the maximum number of lines 
 		let r = 4
 		r * y * e * x
 
-#####Rationale
+##### Rationale
 
 The larger a value becomes the more complex it becomes.
 
-#####How To Fix
+##### How To Fix
 
 Refactor to extract out code into smaller composable functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a value binding. (Default 70)
 
-####MaxLinesInConstructor
+#### MaxLinesInConstructor
 
-#####Cause
+##### Cause
 
 A class constructor is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a constructor becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into private methods or functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a class constructor. (Default 70)
 
-####MaxLinesInMember
+#### MaxLinesInMember
 
-#####Cause
+##### Cause
 
 A member is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a member becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into private methods or functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a member. (Default 70)
 
-####MaxLinesInProperty
+#### MaxLinesInProperty
 
-#####Cause
+##### Cause
 
 A property is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a property becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into private methods or functions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a property. (Default 70)
 
-####MaxLinesInClass
+#### MaxLinesInClass
 
-#####Cause
+##### Cause
 
 A class is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a class becomes the more complex it becomes, it also indicates that it may have [too many different responsibilities](http://en.wikipedia.org/wiki/Single_responsibility_principle).
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into smaller composable classes.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a class. (Default 500)
 
-####MaxLinesInEnum
+#### MaxLinesInEnum
 
-#####Cause
+##### Cause
 
 An enum is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a enum becomes the more complex it becomes, it also indicates that all the items may not be related.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into smaller enums.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a enum. (Default 500)
 
-####MaxLinesInUnion
+#### MaxLinesInUnion
 
-#####Cause
+##### Cause
 
 A discriminated union is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a discriminated union becomes the more complex it becomes, it also indicates that all the items may not be related.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into smaller composed discriminated unions.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a discriminated union. (Default 500)
 
-####MaxLinesInRecord
+#### MaxLinesInRecord
 
-#####Cause
+##### Cause
 
 A record is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a record becomes the more complex it becomes, it also indicates that all the items may not be related.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into smaller composed records.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a record. (Default 500)
 
-####MaxLinesInModule
+#### MaxLinesInModule
 
-#####Cause
+##### Cause
 
 A module is made up of more than a configurable number of lines.
 
-#####Rationale
+##### Rationale
 
 The larger a module becomes the more complex it becomes, it also indicates that it may have too many different responsibilities.
 
-#####How To Fix
+##### How To Fix
 
 Extract code out into smaller modules.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 `Lines` - Maximum number of lines in a module. (Default 1000)

--- a/docs/content/Typography.md
+++ b/docs/content/Typography.md
@@ -1,104 +1,104 @@
-#Typography
+# Typography
 
 Set of rules that analyse the text in a file.
 
-###Analyser Settings
+### Analyser Settings
 
 `Enabled` - A boolean property that can enable and disable this analyser. (Default false)
 
-###Rules
+### Rules
 
-####MaxLinesInFile
+#### MaxLinesInFile
 
-#####Cause
+##### Cause
 
 More than a configurable number of lines were found in a file.
 
-#####Rationale
+##### Rationale
 
 Too many lines in a file indicate it's becoming too complex.
 
-#####How To Fix
+##### How To Fix
 
 Refactor to extract code out into another file.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
 `Lines` - An integer property that specifies the maximum number of lines allowed in a file. (Default 1000)
 
-####MaxCharactersOnLine
+#### MaxCharactersOnLine
 
-#####Cause
+##### Cause
 
 More than a configurable number of characters were on a single line.
 
-#####Rationale
+##### Rationale
 
 Too many characters on a single line make code harder to read by forcing the reader to scroll horizontally.
 
-#####How To Fix
+##### How To Fix
 
 Break the line up into multiple lines.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default false)
 
 `Length` - An integer property that specifies the maximum number of characters allowed on a line. (Default 120)
 
-####NoTabCharacters
+#### NoTabCharacters
 
-#####Cause
+##### Cause
 
 A tab character was found in a file.
 
-#####Rationale
+##### Rationale
 
 It's best practice to use spaces to indent code rather than tabs, this is because tabs have different widths on different platforms.
 
-#####How To Fix
+##### How To Fix
 
 Replace the tab with spaces.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####TrailingNewLineInFile
+#### TrailingNewLineInFile
 
-#####Cause
+##### Cause
 
 A new line was found at the end of a file.
 
-#####Rationale
+##### Rationale
 
 Pointless whitespace.
 
-#####How To Fix
+##### How To Fix
 
 Remove any new lines at the end of a file.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 
-####TrailingWhitespaceOnLine
+#### TrailingWhitespaceOnLine
 
-#####Cause
+##### Cause
 
 Whitespace was found at the end of a line.
 
-#####Rationale
+##### Rationale
 
 Pointless whitespace.
 
-#####How To Fix
+##### How To Fix
 
 Remove any whitespace from the end of the line.
 
-#####Rule Settings
+##### Rule Settings
 
 `Enabled` - A boolean property that can enable and disable this rule. (Default true)
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,4 +1,4 @@
-#FSharpLint
+# FSharpLint
 
 FSharpLint is a lint tool for F#. It can be ran as a MSBuild task, or as a console application.
 
@@ -6,7 +6,7 @@ FSharpLint is a lint tool for F#. It can be ran as a MSBuild task, or as a conso
 
 Using a `.fsproj` (F# project) file the tool will analyse all of the F# implementation files in a project looking for code that breaks a set of rules governing the style of the code. Examples of rules: lambda functions must be less than 6 lines long, class member identifiers must be PascalCase.
 
-####Example Usage of the Tool
+#### Example Usage of the Tool
 
 The following program:
 
@@ -67,11 +67,11 @@ After refactoring again we have with no lint errors:
         printfn "%d" x
         0
 
-####Building The Tool
+#### Building The Tool
 
 On windows run `build.cmd` and on unix based systems run `build.sh`.
 
-####Running The Tool
+#### Running The Tool
 
 The tool can be run from the command line, or as an MSBuild task. 
 
@@ -79,7 +79,7 @@ The tool can be run from the command line, or as an MSBuild task.
 * [Running the MSBuild task](MSBuild-Task.html).
 * [Running the FAKE task](FAKE-Task.html).
 
-####Analysers
+#### Analysers
 
 * [Hints](Hints.html)
 * [NameConventions](NameConventions.html)
@@ -93,7 +93,7 @@ The tool can be run from the command line, or as an MSBuild task.
 
 Rules are grouped into sets of rules called analysers, the reason for this is that it allows for easy configuration of multiple related rules. For example turning off all naming rules can be done by turning off just the analyser in the configuration.
 
-####Configuration Files
+#### Configuration Files
 
 Configuration of the tool is done using xml with a purposely similar structure to [StyleCop](http://stylecop.codeplex.com/). Configuration files must be named: `Settings.FSharpLint`. A single xml file containing the default configuration for all rules is [included inside of the software](https://github.com/fsprojects/FSharpLint/blob/master/src/FSharpLint.Framework/DefaultConfiguration.FSharpLint).
 
@@ -118,13 +118,13 @@ To override to turn off you'd set enabled to false in your own configuration fil
 		</Analysers>
 	</FSharpLintSettings>
 
-####Disabling rules and analysers within code
+#### Disabling rules and analysers within code
 
 To disable a rule for a single section of code the [SuppressMessageAttribute](http://msdn.microsoft.com/en-us/library/system.diagnostics.codeanalysis.suppressmessageattribute(v=vs.110).aspx) can be used. The attribute will not be included into the IL (as long as you don't have the `CODE_ANALYSIS` preprocessing symbol set).
 
 The attribute can be applied to let bindings, modules, types, and exceptions. Any lint warnings generated on or inside of what the attribute is applied to will be suppressed.
 
-#####Category and CheckId
+##### Category and CheckId
 
 Only two properties in the attribute need to be set to suppress a rule, these are: `Category` and `CheckId`. The attribute has a constructor which takes these two as the arguments, and they can also be set through property initialisation in the default constructor.
 
@@ -132,7 +132,7 @@ Category is the name of the analyser containing the rule to be suppressed e.g. `
 
 CheckId is the name of the rule to be suppressed, or `*` to suppress all rules in the analyser e.g. `InterfaceNamesMustBeginWithI`.
 
-#####Example
+##### Example
 
 The following code breaks the rule `NameConventions.InterfaceNamesMustBeginWithI`:
 
@@ -149,7 +149,7 @@ The following code has the `SuppressMessage` attribute applied to it, this code 
     type Printable =
         abstract member Print : unit -> unit
 
-####Ignoring Files
+#### Ignoring Files
 
 In the configuration file paths can be used to specify files that should be included, globs are used to match wildcard directories and files. For example the following will match all files with the file name assemblyinfo (the matching is case insensitive) with any extension:
 
@@ -165,7 +165,7 @@ In the configuration file paths can be used to specify files that should be incl
 * If the path ends with a `/` then everything inside of a matching directory shall be excluded.
 * If the path does not end with a `/` then all matching files are excluded.
 
-####Running Lint From An Application
+#### Running Lint From An Application
 
 Install the [`FSharp.Core` nuget package](https://www.nuget.org/packages/FSharpLint.Core/).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
