### PR TITLE
Update template.cshtml - remove CyclomaticComplexity from menu

### DIFF
--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -72,7 +72,6 @@
             <li><a href="FunctionReimplementation.html">FunctionReimplementation</a></li>
             <li><a href="XmlDocumentation.html">XmlDocumentation</a></li>
             <li><a href="Binding.html">Binding</a></li>
-            <li><a href="CyclomaticComplexity.html">CyclomaticComplexity</a></li>
             <li><a href="RaiseWithTooManyArguments.html">RaiseWithTooManyArguments</a></li>
           </ul>
         </div>


### PR DESCRIPTION
CyclomaticComplexity analyzer is no longer in FSharpLint, and clicking on the link results in 404