### PR TITLE
.NET Core FSharpLint.Console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 
 sudo: false  # use the new container-based Travis infrastructure 
 
-dotnet: 2.1.0
+dotnet: 2.1
 
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 
 sudo: false  # use the new container-based Travis infrastructure 
 
-dotnet: 2.0.0
+dotnet: 2.1.0
 
 script:
   - ./build.sh

--- a/FSharpLint.netstandard.sln
+++ b/FSharpLint.netstandard.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1CD44876
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharpLint.Core.Tests.netstandard", "tests/FSharpLint.Core.Tests.netstandard/FSharpLint.Core.Tests.netstandard.fsproj", "{D89BCE82-E334-49F8-8144-7F1EF6A0023C}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpLint.Console.NetCore", "src\FSharpLint.Console.NetCore\FSharpLint.Console.NetCore.fsproj", "{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,18 @@ Global
 		{D89BCE82-E334-49F8-8144-7F1EF6A0023C}.Release|x64.Build.0 = Release|Any CPU
 		{D89BCE82-E334-49F8-8144-7F1EF6A0023C}.Release|x86.ActiveCfg = Release|Any CPU
 		{D89BCE82-E334-49F8-8144-7F1EF6A0023C}.Release|x86.Build.0 = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|x64.Build.0 = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -51,6 +65,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5C73A4D1-2E00-4FB8-B3B3-6F71B4D7628A} = {40C2798B-7078-4D4F-BD37-195240CB827B}
 		{D89BCE82-E334-49F8-8144-7F1EF6A0023C} = {1CD44876-BCDC-4C93-9DC2-C45244BD62AE}
+		{CFE69FAA-B8D1-4EAC-B594-9A5173ED26B7} = {40C2798B-7078-4D4F-BD37-195240CB827B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B54B4B7D-F019-48A3-BB5B-635B68FE41C3}

--- a/src/FSharpLint.Console.NetCore/FSharpLint.Console.NetCore.fsproj
+++ b/src/FSharpLint.Console.NetCore/FSharpLint.Console.NetCore.fsproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\FSharpLint.Console\Program.fs">
-    </Compile>
+    <Compile Include="..\FSharpLint.Console\Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSharpLint.Console.NetCore/FSharpLint.Console.NetCore.fsproj
+++ b/src/FSharpLint.Console.NetCore/FSharpLint.Console.NetCore.fsproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DefineConstants>NO_PROJECTCRACKER;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\FSharpLint.Console\Program.fs">
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FSharpLint.Core.netstandard\FSharpLint.Core.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FSharpLint.Console.NetCore/Program.fs
+++ b/src/FSharpLint.Console.NetCore/Program.fs
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    0 // return an integer exit code

--- a/src/FSharpLint.Console.NetCore/Program.fs
+++ b/src/FSharpLint.Console.NetCore/Program.fs
@@ -1,8 +1,0 @@
-﻿// Learn more about F# at http://fsharp.org
-
-open System
-
-[<EntryPoint>]
-let main argv =
-    printfn "Hello World from F#!"
-    0 // return an integer exit code

--- a/src/FSharpLint.Console/Program.fs
+++ b/src/FSharpLint.Console/Program.fs
@@ -7,7 +7,13 @@ module Program =
     open FSharpLint.Application
 
     let private help () =
-        Resources.GetString("ConsoleHelp") |> Console.WriteLine
+
+#if NO_PROJECTCRACKER
+#else
+        printfn "-f <project.fsproj>        lint project"
+#endif
+        printfn "-sf <file.fs>              lint single file"
+        printfn "-source 'let foo = 5'      lint source code"
 
     let private printException (e:Exception) =
         "Exception Message:" + Environment.NewLine +
@@ -36,8 +42,12 @@ module Program =
             { CancellationToken = None
               ReceivedWarning = Some warningReceived
               Configuration = None }
-
+    
+#if NO_PROJECTCRACKER
+        ()
+#else
         lintProject parseInfo projectFile (Some parserProgress)
+#endif
 
     let private runLintOnFile pathToFile =
         let reportLintWarning (warning:LintWarning.Warning) =

--- a/src/FSharpLint.Console/Program.fs
+++ b/src/FSharpLint.Console/Program.fs
@@ -44,7 +44,7 @@ module Program =
               Configuration = None }
     
 #if NO_PROJECTCRACKER
-        ()
+        failwith "this build does not support project files."
 #else
         lintProject parseInfo projectFile (Some parserProgress)
 #endif

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -132,9 +132,6 @@
   <data name="ConsoleFinished" xml:space="preserve">
     <value>Finished.</value>
   </data>
-  <data name="ConsoleHelp" xml:space="preserve">
-    <value>Use -f followed by the absolute path of the .fsproj file of the project to lint to run the tool.</value>
-  </data>
   <data name="ConsoleMSBuildFailedToLoadProjectFile" xml:space="preserve">
     <value>MSBuild could not load the project file {0} because: {1}</value>
   </data>


### PR DESCRIPTION
This PR builds on https://github.com/fsprojects/FSharpLint/pull/241 (.NET Standard support) by adding a separate .NET Core project for FSharpLint.Console.

As in `FSharpLint.Core.netstandard`, support for legacy .fsproj is excluded with `NO_PROJECTCRACKER`.

I've also added usage information for `-sf` and `-source`, and moved it from FSharpLint.Core's resource file to the command line tool's source.

Hopefully this moves us a step closer toward https://github.com/fsprojects/FSharpLint/issues/267 .