### PR TITLE
Add indentation rule

### DIFF
--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -172,6 +172,15 @@
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
+
+            <xs:element name="Indentation" maxOccurs="1" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Enabled" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                  <xs:element name="NumberOfIndentationSpaces" maxOccurs="1" minOccurs="0" type="xs:unsignedInt" />
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/src/FSharpLint.Console/FSharpLint.Console.fsproj
+++ b/src/FSharpLint.Console/FSharpLint.Console.fsproj
@@ -13,6 +13,7 @@
     <Name>FSharpLint.Console</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -327,6 +327,11 @@
           <OneSpaceAllowedAfterOperator>true</OneSpaceAllowedAfterOperator>
           <IgnoreBlankLines>true</IgnoreBlankLines>
         </TrailingWhitespaceOnLine>
+
+        <Indentation>
+          <Enabled>true</Enabled>
+          <NumberOfIndentationSpaces>4</NumberOfIndentationSpaces>
+        </Indentation>
       </Rules>
       <Enabled>true</Enabled>
     </Typography>

--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -329,7 +329,7 @@
         </TrailingWhitespaceOnLine>
 
         <Indentation>
-          <Enabled>true</Enabled>
+          <Enabled>false</Enabled>
           <NumberOfIndentationSpaces>4</NumberOfIndentationSpaces>
         </Indentation>
       </Rules>

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -13,6 +13,7 @@
     <Name>FSharpLint.Core</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/FSharpLint.Core/Framework/Configuration.fs
+++ b/src/FSharpLint.Core/Framework/Configuration.fs
@@ -67,6 +67,7 @@ module Configuration =
         | Hints of Hints
         | OneSpaceAllowedAfterOperator of bool
         | NumberOfSpacesAllowed of int
+        | NumberOfIndentationSpaces of int
         | IgnoreBlankLines of bool
         | Access of Access
         | Naming of Naming
@@ -80,6 +81,7 @@ module Configuration =
         | MaxItems(x)
         | Length(x)
         | NumberOfSpacesAllowed(x) -> x :> obj
+        | NumberOfIndentationSpaces(x) -> x :> obj
         | Underscores(x) -> x :> obj
         | Prefix(x)
         | Suffix(x) -> x :> obj
@@ -275,6 +277,7 @@ module Configuration =
         | "Hints" -> Hints(parseHints setting)
         | "OneSpaceAllowedAfterOperator" -> OneSpaceAllowedAfterOperator(setting.Value |> bool.Parse)
         | "NumberOfSpacesAllowed" -> NumberOfSpacesAllowed(setting.Value |> int)
+        | "NumberOfIndentationSpaces" -> NumberOfIndentationSpaces(setting.Value |> int)
         | "IgnoreBlankLines" -> IgnoreBlankLines(setting.Value |> bool.Parse)
         | "Access" -> Access(setting.Value |> fromEnum "Access")
         | "Naming" -> Naming(setting.Value |> fromEnum "Naming")

--- a/src/FSharpLint.Core/Framework/Utilities.fs
+++ b/src/FSharpLint.Core/Framework/Utilities.fs
@@ -11,6 +11,16 @@ module Utilities =
         
     let (</>) x y = System.IO.Path.Combine(x, y)
 
+module Dictionary =
+
+    open System.Collections.Generic
+
+    let addOrUpdate key value (dict:Dictionary<'key,'value>) =
+        if dict.ContainsKey(key) then
+            dict.Remove(key) |> ignore
+
+        dict.Add(key, value)
+
 module ExpressionUtilities =
 
     open Microsoft.FSharp.Compiler

--- a/src/FSharpLint.Core/Rules/Typography.fs
+++ b/src/FSharpLint.Core/Rules/Typography.fs
@@ -172,9 +172,10 @@ module Typography =
                 if numLeadingSpaces % expectedSpaces <> 0 then
                     let range = mkRange (mkPos lineNumber 0) (mkPos lineNumber numLeadingSpaces)
                     if isSuppressed range "Indentation" |> not then
+                        let errorFormatString = Resources.GetString("RulesTypographyIndentationError")
                         analyserInfo.Suggest
                             { Range = range
-                              Message = sprintf "Indentation must use a multiple of %i spaces." expectedSpaces
+                              Message =  String.Format(errorFormatString, expectedSpaces) 
                               SuggestedFix = None
                               TypeChecks = [] })
 

--- a/src/FSharpLint.Core/Rules/Typography.fs
+++ b/src/FSharpLint.Core/Rules/Typography.fs
@@ -174,7 +174,7 @@ module Typography =
                 if isSuppressed range "Indentation" |> not then
                     if indentationOverrides.ContainsKey lineNumber then
                         if numLeadingSpaces <> indentationOverrides.[lineNumber] then
-                            let errorString = Resources.GetString("RulesTypographyRecordFieldIndentationError")
+                            let errorString = Resources.GetString("RulesTypographyOverridenIndentationError")
                             analyserInfo.Suggest
                                 { Range = range
                                   Message =  errorString

--- a/src/FSharpLint.Core/Rules/Typography.fs
+++ b/src/FSharpLint.Core/Rules/Typography.fs
@@ -281,6 +281,10 @@ module Typography =
                         |> List.iter (fun exprRange ->
                             indentationOverrides.Add(exprRange.StartLine, expectedIndentation) |> ignore)
                     | _ -> ()
+                | Expression(SynExpr.App(funcExpr=(SynExpr.App(funcExpr=SynExpr.Ident(ident); argExpr=innerArg)); argExpr=outerArg))
+                    when ident.idText = "op_PipeRight" ->
+                    let expectedIndentation = innerArg.Range.StartColumn
+                    indentationOverrides.Add(outerArg.Range.StartLine, expectedIndentation) |> ignore
                 | _ -> ()
 
             let rangeContainsOtherRange (containingRange:range) (range:range) =

--- a/src/FSharpLint.Core/Rules/Typography.fs
+++ b/src/FSharpLint.Core/Rules/Typography.fs
@@ -317,6 +317,18 @@ module Typography =
                     [(outerArg.Range.StartLine + 1)..outerArg.Range.EndLine]
                     |> List.iter (fun offsetLine ->
                         Dictionary.addOrUpdate offsetLine (Indentation.Offset(expectedIndentation)) indentationOverrides)
+                | Expression(SynExpr.ObjExpr(bindings=bindings; newExprRange=newExprRange)) ->
+                    let expectedIndentation = newExprRange.StartColumn + 4
+                    let bindingRanges =
+                        bindings
+                        |> List.map (fun binding -> binding.RangeOfBindingAndRhs)
+                        |> firstRangePerLine
+                    bindingRanges
+                    |> List.iter (fun bindingRange ->
+                        Dictionary.addOrUpdate bindingRange.StartLine (Indentation.Absolute(expectedIndentation)) indentationOverrides
+                        [(bindingRange.StartLine + 1)..bindingRange.EndLine]
+                        |> List.iter (fun offsetLine ->
+                            Dictionary.addOrUpdate offsetLine (Indentation.Offset(expectedIndentation)) indentationOverrides))
                 | _ -> ()
 
             let rangeContainsOtherRange (containingRange:range) (range:range) =

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -291,4 +291,7 @@
   <data name="RulesConventionsTopLevelNamespaceError" xml:space="preserve">
     <value>Prefer namespaces at top level.</value>
   </data>
+  <data name="RulesTypographyIndentationError" xml:space="preserve">
+    <value>Indentation must use a multiple of {0} spaces.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -294,4 +294,7 @@
   <data name="RulesTypographyIndentationError" xml:space="preserve">
     <value>Indentation must use a multiple of {0} spaces.</value>
   </data>
+  <data name="RulesTypographyRecordFieldIndentationError" xml:space="preserve">
+    <value>Record fields should be aligned.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -297,4 +297,7 @@
   <data name="RulesTypographyRecordFieldIndentationError" xml:space="preserve">
     <value>Record fields should be aligned.</value>
   </data>
+  <data name="RulesTypographyOverridenIndentationError" xml:space="preserve">
+    <value>Invalid indentation.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Fake/FSharpLint.Fake.fsproj
+++ b/src/FSharpLint.Fake/FSharpLint.Fake.fsproj
@@ -65,6 +65,9 @@
     <Reference Include="FakeLib">
       <HintPath>..\..\packages\FAKE.Lib\lib\net451\FakeLib.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Compiler.Service">
+      <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+    </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>

--- a/src/FSharpLint.Fake/FSharpLint.Fake.fsproj
+++ b/src/FSharpLint.Fake/FSharpLint.Fake.fsproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -63,9 +64,6 @@
   <ItemGroup>
     <Reference Include="FakeLib">
       <HintPath>..\..\packages\FAKE.Lib\lib\net451\FakeLib.dll</HintPath>
-    </Reference>
-    <Reference Include="FSharp.Compiler.Service">
-      <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>

--- a/src/FSharpLint.MSBuild/FSharpLint.MSBuild.fsproj
+++ b/src/FSharpLint.MSBuild/FSharpLint.MSBuild.fsproj
@@ -14,6 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -13,6 +13,7 @@
     <Name>FSharpLint.Core.Tests</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -297,3 +297,26 @@ let pascalsTriangle =
     ]"""
 
         Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional pipeline indentation``() =
+        this.Parse """
+module P
+
+let res = 1
+          |> add 2
+          |> sub 3"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for standard pipeline indentation``() =
+        this.Parse """
+module P
+
+let res =
+    1
+    |> add 2
+    |> sub 3"""
+
+        Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -262,6 +262,17 @@ let rainbow =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for correct record field indentation with multiple fields per line``() =
+        this.Parse """
+module P
+
+let rainbow =
+    { X = "X"; Z = "Z"
+      Y = "Y"; W = "W"}"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for correct array member indentation``() =
         this.Parse """
 module P

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -273,6 +273,19 @@ let rainbow =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for correct multiline record field indentation``() =
+        this.Parse """
+module P
+
+let rainbow =
+    { X =
+        (fun x ->
+            x + 1)
+      Y = "Y"}"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for correct array member indentation``() =
         this.Parse """
 module P
@@ -318,5 +331,33 @@ let res =
     1
     |> add 2
     |> sub 3"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional multiline pipeline indentation``() =
+        this.Parse """
+module P
+
+let res = 1
+          |> (fun x ->
+              x + 1)
+          |> (fun x ->
+              x - 3)"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional object expression indentation``() =
+        this.Parse """
+module P
+
+let comparer =
+    { new IComparer<string> with
+          member x.Compare(s1, s2) =
+              let rev (s : String) =
+                  new String (Array.rev (s.ToCharArray()))
+              let reversed = rev s1 i
+              reversed.CompareTo (rev s2) }"""
 
         Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -24,7 +24,7 @@ let setupConfig numberOfSpacesAllowed numberOfIndentationSpaces isOneSpaceAllowe
                                     Settings = Map.ofList
                                         [ 
                                             ("Enabled", Enabled(true))
-                                            ("Length", Length(20))
+                                            ("Length", Length(40))
                                         ] 
                                 }) 
                             ("NoTabCharacters", 
@@ -87,7 +87,7 @@ type TestTypography() =
     member this.TooManyCharactersOnLine() = 
         this.Parse "let line = 55 + 77 + 77 + 55 + 55 + 55 + 77 + 55 + 55 + 77 + 55 + 55 + 77 + 77"
 
-        Assert.IsTrue(this.ErrorExistsAt(1, 21))
+        Assert.IsTrue(this.ErrorExistsAt(1, 41))
 
     [<Test>]
     member this.TooManyCharactersOnLineSuppressed() = 
@@ -258,5 +258,31 @@ module P
 let rainbow =
     { X = "X"
       Y = "Y"}"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for correct array member indentation``() =
+        this.Parse """
+module P
+
+let pascalsTriangle =
+    [| 1
+       2
+       3
+    |]"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for correct list member indentation``() =
+        this.Parse """
+module P
+
+let pascalsTriangle =
+    [ 1
+      2
+      3
+    ]"""
 
         Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -24,7 +24,7 @@ let setupConfig numberOfSpacesAllowed numberOfIndentationSpaces isOneSpaceAllowe
                                     Settings = Map.ofList
                                         [ 
                                             ("Enabled", Enabled(true))
-                                            ("Length", Length(40))
+                                            ("Length", Length(60))
                                         ] 
                                 }) 
                             ("NoTabCharacters", 
@@ -87,7 +87,7 @@ type TestTypography() =
     member this.TooManyCharactersOnLine() = 
         this.Parse "let line = 55 + 77 + 77 + 55 + 55 + 55 + 77 + 55 + 55 + 77 + 55 + 55 + 77 + 77"
 
-        Assert.IsTrue(this.ErrorExistsAt(1, 41))
+        Assert.IsTrue(this.ErrorExistsAt(1, 61))
 
     [<Test>]
     member this.TooManyCharactersOnLineSuppressed() = 

--- a/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestTypographyRules.fs
@@ -24,7 +24,7 @@ let setupConfig numberOfSpacesAllowed numberOfIndentationSpaces isOneSpaceAllowe
                                     Settings = Map.ofList
                                         [ 
                                             ("Enabled", Enabled(true))
-                                            ("Length", Length(10))
+                                            ("Length", Length(20))
                                         ] 
                                 }) 
                             ("NoTabCharacters", 
@@ -85,9 +85,9 @@ type TestTypography() =
 
     [<Test>]
     member this.TooManyCharactersOnLine() = 
-        this.Parse "let line = 55 + 77 + 77"
+        this.Parse "let line = 55 + 77 + 77 + 55 + 55 + 55 + 77 + 55 + 55 + 77 + 55 + 55 + 77 + 77"
 
-        Assert.IsTrue(this.ErrorExistsAt(1, 11))
+        Assert.IsTrue(this.ErrorExistsAt(1, 21))
 
     [<Test>]
     member this.TooManyCharactersOnLineSuppressed() = 
@@ -236,5 +236,27 @@ module P
 
 let x =
     x"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Error for incorrect record field indentation``() =
+        this.Parse """
+module P
+
+let rainbow =
+    { X = "X"
+          Y = "Y"}"""
+
+        Assert.IsTrue(this.ErrorExistsAt(6, 0))
+
+    [<Test>]
+    member this.``No error for correct record field indentation``() =
+        this.Parse """
+module P
+
+let rainbow =
+    { X = "X"
+      Y = "Y"}"""
 
         Assert.IsTrue(this.NoErrorsExist)


### PR DESCRIPTION
Adds a configurable `Indentation` rule to the Typography analyser, which checks that indentation uses a consistent number of spaces (4 by default).