### PR TITLE
Make typed item colon spacing configurable

### DIFF
--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -266,12 +266,27 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:simpleType name="TypedItemStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NoSpaces" />
+      <xs:enumeration value="SpaceAfter" />
+      <xs:enumeration value="SpacesAround" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="Formatting">
     <xs:sequence>
       <xs:element name="Rules" maxOccurs="1" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="TypedItemSpacing" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="TypedItemSpacing" maxOccurs="1" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Enabled" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                  <xs:element name="TypedItemStyle" maxOccurs="1" minOccurs="0" type="TypedItemStyle" />
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
             <xs:element name="TupleCommaSpacing" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TupleParentheses" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TypePrefixing" maxOccurs="1" minOccurs="0" type="Enabled" />

--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -436,7 +436,8 @@
     <Formatting>
       <Rules>
         <TypedItemSpacing>
-          <Enabled>true</Enabled>
+          <Enabled>false</Enabled>
+          <TypedItemStyle>NoSpaces</TypedItemStyle>
         </TypedItemSpacing>
         <TupleCommaSpacing>
           <Enabled>true</Enabled>

--- a/src/FSharpLint.Core/Framework/Configuration.fs
+++ b/src/FSharpLint.Core/Framework/Configuration.fs
@@ -54,6 +54,11 @@ module Configuration =
         | AllowAny = 1
         | None = 2
 
+    type TypedItemStyle =
+        | NoSpaces = 0
+        | SpaceAfter = 1
+        | SpacesAround = 2
+
     type Hint = { Hint: string; ParsedHint: HintParser.Hint }
 
     type Hints = { Hints: Hint list; Update: Update }
@@ -74,6 +79,7 @@ module Configuration =
         | Prefix of string option
         | Suffix of string option
         | Underscores of NamingUnderscores
+        | TypedItemStyle of TypedItemStyle
 
     let private settingToXml = function
         | Lines(x)
@@ -83,6 +89,7 @@ module Configuration =
         | NumberOfSpacesAllowed(x) -> x :> obj
         | NumberOfIndentationSpaces(x) -> x :> obj
         | Underscores(x) -> x :> obj
+        | TypedItemStyle(x) -> x :> obj
         | Prefix(x)
         | Suffix(x) -> x :> obj
         | OneSpaceAllowedAfterOperator(x)
@@ -278,6 +285,7 @@ module Configuration =
         | "OneSpaceAllowedAfterOperator" -> OneSpaceAllowedAfterOperator(setting.Value |> bool.Parse)
         | "NumberOfSpacesAllowed" -> NumberOfSpacesAllowed(setting.Value |> int)
         | "NumberOfIndentationSpaces" -> NumberOfIndentationSpaces(setting.Value |> int)
+        | "TypedItemStyle" -> TypedItemStyle(setting.Value |> fromEnum "TypedItemStyle")
         | "IgnoreBlankLines" -> IgnoreBlankLines(setting.Value |> bool.Parse)
         | "Access" -> Access(setting.Value |> fromEnum "Access")
         | "Naming" -> Naming(setting.Value |> fromEnum "Naming")

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -253,7 +253,7 @@
     <value>Use parentheses for tuple instantiation.</value>
   </data>
   <data name="RulesFormattingTypedItemSpacingError" xml:space="preserve">
-    <value>Use spaces around ':' in typed item.</value>
+    <value>Expected {0} space(s) before and {1} space(s) after ':' in typed item.</value>
   </data>
   <data name="RulesFormattingF#ArrayPostfixError" xml:space="preserve">
     <value>Use special postfix syntax for F# type array.</value>

--- a/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
@@ -4,13 +4,22 @@ open NUnit.Framework
 open FSharpLint.Rules.Formatting
 open FSharpLint.Framework.Configuration
 
-let config = 
+let typedItemSpacingConfig style =
+    { 
+        Settings = Map.ofList
+            [ 
+                ("Enabled", Enabled(true))
+                ("TypedItemStyle", TypedItemStyle(style))
+            ] 
+    }
+
+let config typedItemSpacingStyle = 
     let ruleEnabled = { Rule.Settings = Map.ofList [ ("Enabled", Enabled(true)) ] }
 
     Map.ofList 
         [ (AnalyserName, 
             { Rules = Map.ofList 
-                [ ("TypedItemSpacing", ruleEnabled)
+                [ ("TypedItemSpacing", typedItemSpacingConfig typedItemSpacingStyle)
                   ("TupleCommaSpacing", ruleEnabled)
                   ("TupleParentheses", ruleEnabled)
                   ("TypePrefixing", ruleEnabled)
@@ -22,20 +31,74 @@ let config =
                   ("PatternMatchClauseIndentation", ruleEnabled)
                   ("PatternMatchExpressionIndentation", ruleEnabled) ]
               Settings = Map.ofList [ ("Enabled", Enabled(true)) ] }) ]
- 
-              
+
 [<TestFixture>]
-type TestFormatting() =
-    inherit TestRuleBase.TestRuleBase(analyser, config)
+type TestFormattingTypedItemSpaceAfter() =
+    inherit TestRuleBase.TestRuleBase(analyser, config TypedItemStyle.SpaceAfter)
 
     [<Test>]
-    member this.``Error for typed pattern without spaces around colon``() = 
+    member this.``No error for typed pattern with space after colon``() = 
+        this.Parse("""
+module Program
+
+let (x: int) = 1""")
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Error for typed pattern with no spaces around colon``() = 
         this.Parse("""
 module Program
 
 let (x:int) = 1""")
 
         Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with no spaces around colon``() = 
+        let source = """
+module Program
+
+let (x:int) = 1"""
+
+
+        let expected = """
+module Program
+
+let (x: int) = 1"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+    [<Test>]
+    member this.``Error for typed pattern with spaces around colon``() = 
+        this.Parse("""
+module Program
+
+let (x : int) = 1""")
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with spaces around colon``() = 
+        let source = """
+module Program
+
+let (x : int) = 1"""
+
+
+        let expected = """
+module Program
+
+let (x: int) = 1"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+
+[<TestFixture>]
+type TestFormattingTypedItemSpacesAround() =
+    inherit TestRuleBase.TestRuleBase(analyser, config TypedItemStyle.SpacesAround)
 
     [<Test>]
     member this.``No error for typed pattern with spaces around colon``() = 
@@ -47,7 +110,16 @@ let (x : int) = 1""")
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``Quickfix for typed pattern with missing spaces``() = 
+    member this.``Error for typed pattern with no spaces around colon``() = 
+        this.Parse("""
+module Program
+
+let (x:int) = 1""")
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with spaces around colon``() = 
         let source = """
 module Program
 
@@ -62,6 +134,97 @@ let (x : int) = 1"""
         this.Parse source
         Assert.AreEqual(expected, this.ApplyQuickFix source)
 
+    [<Test>]
+    member this.``Error for typed pattern with space after colon``() = 
+        this.Parse("""
+module Program
+
+let (x: int) = 1""")
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with space after colon``() = 
+        let source = """
+module Program
+
+let (x: int) = 1"""
+
+
+        let expected = """
+module Program
+
+let (x : int) = 1"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)
+              
+[<TestFixture>]
+type TestFormattingTypedItemNoSpaces() =
+    inherit TestRuleBase.TestRuleBase(analyser, config TypedItemStyle.NoSpaces)
+
+    [<Test>]
+    member this.``No error for typed pattern with no spaces around colon``() = 
+        this.Parse("""
+module Program
+
+let (x:int) = 1""")
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Error for typed pattern with spaces around colon``() = 
+        this.Parse("""
+module Program
+
+let (x : int) = 1""")
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with spaces around colon``() = 
+        let source = """
+module Program
+
+let (x : int) = 1"""
+
+
+        let expected = """
+module Program
+
+let (x:int) = 1"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+    [<Test>]
+    member this.``Error for typed pattern with space after colon``() = 
+        this.Parse("""
+module Program
+
+let (x: int) = 1""")
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 5))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with space after colon``() = 
+        let source = """
+module Program
+
+let (x: int) = 1"""
+
+
+        let expected = """
+module Program
+
+let (x:int) = 1"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+[<TestFixture>]
+type TestFormatting() =
+    inherit TestRuleBase.TestRuleBase(analyser, config TypedItemStyle.NoSpaces)
     
     [<Test>]
     member this.``Error for tuple instantiation without parentheses``() =


### PR DESCRIPTION
Addresses #276, adding configuration for the Formatting analyser's TypedItemSpacing rule. There are 3 settings:

- NoSpaces `(x:int)`
- SpaceAfter `(x: int)`
- SpacesAround `(x : int)`