### PR TITLE
Implement RecursiveAsyncFunction rule.

### DIFF
--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -316,6 +316,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element name="TopLevelNamespace" maxOccurs="1" minOccurs="0" type="Enabled" />
+            <xs:element name="RecursiveAsyncFunction" maxOccurs="1" minOccurs="0" type="Enabled" />
           </xs:sequence>
         </xs:complexType>
       </xs:element>

--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -478,6 +478,9 @@
         <TopLevelNamespace>
           <Enabled>true</Enabled>
         </TopLevelNamespace>
+        <RecursiveAsyncFunction>
+          <Enabled>false</Enabled>
+        </RecursiveAsyncFunction>
       </Rules>
       <Enabled>true</Enabled>
     </Conventions>

--- a/src/FSharpLint.Core/Rules/Conventions.fs
+++ b/src/FSharpLint.Core/Rules/Conventions.fs
@@ -6,6 +6,8 @@ module Conventions =
     open FSharpLint.Framework.Analyser
     open FSharpLint.Framework.Configuration
     open Microsoft.FSharp.Compiler.Ast
+    open Microsoft.FSharp.Compiler.Range
+    open Microsoft.FSharp.Compiler.SourceCodeServices
     open FSharpLint.Framework.Ast
 
     [<Literal>]
@@ -34,6 +36,65 @@ module Conventions =
                           SuggestedFix = None
                           TypeChecks = [] }
 
+    module private RecursiveAsyncFunction =
+
+        let private isAsyncCompExpr = function
+            | SynExpr.App (_, _, (SynExpr.Ident compExprName), (SynExpr.CompExpr _), _)
+                when compExprName.idText = "async" ->
+                    true
+            | _ -> false
+
+        let rec private getIdentFromSynPat = function
+            | SynPat.LongIdent (longDotId=longDotId) ->
+                longDotId
+                |> ExpressionUtilities.longIdentWithDotsToString
+                |> Some
+            | SynPat.Typed (pat, _, _) ->
+                getIdentFromSynPat pat
+            | _ -> 
+                None
+
+        let private getFunctionNameFromAsyncCompExprBinding = function
+            | SynBinding.Binding (headPat=headPat; expr=expr) when isAsyncCompExpr expr ->
+                getIdentFromSynPat headPat
+            | _ -> 
+                None
+
+        let checkRecursiveAsyncFunction args (range:range) (doBangExpr:SynExpr) breadcrumbs isSuppressed =
+            let ruleName = "RecursiveAsyncFunction"
+
+            let isEnabled = isEnabled ruleName args.Info.Config
+
+            if isEnabled && isSuppressed ruleName |> not then
+                let doTokenRange = mkRange "do!" (mkPos range.StartLine range.StartColumn) (mkPos range.StartLine (range.StartColumn + 3))
+                match doBangExpr with
+                | SynExpr.App (funcExpr=(SynExpr.Ident callerIdent)) ->
+                    breadcrumbs
+                    |> List.collect (fun crumb ->
+                        match crumb with
+                        | AstNode.ModuleDeclaration (SynModuleDecl.Let (true, bindings, _)) ->
+                            bindings
+                        | AstNode.Expression (SynExpr.LetOrUse (true, false, bindings, _, _)) ->
+                            bindings
+                        | _ -> [])
+                    |> List.choose getFunctionNameFromAsyncCompExprBinding
+                    |> List.filter ((=) callerIdent.idText)
+                    |> List.iter (fun _ ->
+                        let suggestedFix = lazy(
+                            args.Info.TryFindTextOfRange doTokenRange
+                            |> Option.map (fun fromText -> 
+                                { FromText = fromText
+                                  FromRange = doTokenRange
+                                  ToText = "return!" }))
+
+                        args.Info.Suggest
+                            { Range = range 
+                              Message = Resources.GetString("RulesConventionsRecursiveAsyncFunctionError")
+                              SuggestedFix = Some suggestedFix
+                              TypeChecks = [] }
+                    )
+                | _ -> ()
+
     let analyser (args: AnalyserArgs) : unit = 
         if isAnalyserEnabled args.Info.Config then
             let syntaxArray, skipArray = args.SyntaxArray, args.SkipArray
@@ -49,3 +110,11 @@ module Conventions =
                 | AstNode.ModuleOrNamespace moduleOrNamespace ->
                     TopLevelNamespace.checkTopLevelNamespace args moduleOrNamespace.Range moduleOrNamespace (isSuppressed 0)
                 | _ -> ())
+
+            for i = 0 to syntaxArray.Length - 1 do
+                let node = syntaxArray.[i].Actual
+                match node with 
+                | AstNode.Expression (SynExpr.DoBang (expr, range)) ->
+                    let breadcrumbs = AbstractSyntaxArray.getBreadcrumbs 5 syntaxArray skipArray i
+                    RecursiveAsyncFunction.checkRecursiveAsyncFunction args range expr breadcrumbs (isSuppressed i)
+                | _ -> ()

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -300,4 +300,7 @@
   <data name="RulesTypographyOverridenIndentationError" xml:space="preserve">
     <value>Invalid indentation.</value>
   </data>
+  <data name="RulesConventionsRecursiveAsyncFunctionError" xml:space="preserve">
+    <value>Recursive async functions ending with a `do!` recursive call will leak memory; prefer `return!`.</value>
+  </data>
 </root>


### PR DESCRIPTION
Checks for tail-recursive async functions which make their recursive call with `do!`. This can cause memory leaks; the recursive call should be made with `return!`. See [this stack overflow](https://stackoverflow.com/questions/33481220/memory-leak-in-f-async-recursive-call) question for more info.