### PR TITLE
Fix guard indentation in FormattingMatchExpressionIndentation rule

### DIFF
--- a/src/FSharpLint.Core/Rules/Formatting.fs
+++ b/src/FSharpLint.Core/Rules/Formatting.fs
@@ -214,8 +214,12 @@ module Formatting =
             if isEnabled && isSuppressed ruleName |> not then
                 clauses
                 |> List.iter (fun clause ->
-                    let (SynMatchClause.Clause (pat, _, expr, _, _)) = clause
-                    if expr.Range.StartLine <> pat.Range.EndLine 
+                    let (SynMatchClause.Clause (pat, guard, expr, _, _)) = clause
+                    let matchPatternEndLine =
+                        guard
+                        |> Option.map (fun expr -> expr.Range.EndLine)
+                        |> Option.defaultValue pat.Range.EndLine 
+                    if expr.Range.StartLine <> matchPatternEndLine
                     && expr.Range.StartColumn - 2 <> pat.Range.StartColumn then
                       args.Info.Suggest
                         { Range = expr.Range

--- a/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
@@ -692,7 +692,7 @@ match 1 with
 | 1 -> 
 true
 | 2 -> 
-    false)
+    false
 """
 
         Assert.IsTrue(this.ErrorExistsAt(6, 0))
@@ -706,7 +706,19 @@ match 1 with
 | 1 -> 
     true
 | 2 -> 
-    false)
+    false
+"""
+
+    [<Test>]
+    member this.``No error for multi-line pattern match clauses with same indentation``() =
+        this.Parse"""
+module Program
+
+match "x" with
+| "a" when 5 > 3 &&
+           4 < 8 &&
+           2 > 9 -> "result"
+| _ -> "otherresult"
 """
 
         Assert.IsTrue(this.NoErrorsExist)


### PR DESCRIPTION
We were not taking the guard of a pattern match into account for the match expression indentation rule in the Formatting analyser.

Fixes #286.