### PR TITLE
Add C# interop members to LintResult type

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -95,6 +95,7 @@ module Lint =
     open System.Collections.Concurrent
     open System.Collections.Generic
     open System.IO
+    open System.Runtime.InteropServices
     open System.Threading
     open Microsoft.FSharp.Compiler.SourceCodeServices
     open FSharpLint
@@ -368,6 +369,16 @@ module Lint =
     type LintResult =
         | Success of LintWarning.Warning list
         | Failure of LintFailure
+
+        member self.TryGetSuccess([<Out>] success:byref<LintWarning.Warning list>) =
+            match self with
+            | Success value -> success <- value; true
+            | _ -> false
+        member self.TryGetFailure([<Out>] failure:byref<LintFailure>) =
+            match self with
+            | Failure value -> failure <- value; true
+            | _ -> false
+
 
     /// Optional parameters that can be provided to the linter.
     [<NoEquality; NoComparison>]

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -123,6 +123,9 @@ module Lint =
     type LintResult = 
         | Success of LintWarning.Warning list
         | Failure of LintFailure
+
+        member TryGetSuccess : byref<LintWarning.Warning list> -> bool
+        member TryGetFailure : byref<LintFailure> -> bool
         
     /// Lints an entire F# project by retrieving the files from a given 
     /// path to the `.fsproj` file.


### PR DESCRIPTION
Adds `TryGetSuccess` and `TryGetFailure` methods to `LintResult` type, to support interoperability with C#.