### PR TITLE
fix using FSharpLint.Core targeting `net`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: false  # use the new container-based Travis infrastructure
 
 dotnet: 2.1
 
+install:
+  # workaround for missing .net 4.6.1 targing pack
+  - export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.6.1-api/
+
 script:
   - ./build.sh
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,7 @@ source https://api.nuget.org/v3/index.json
 
 nuget FParsec
 nuget FSharp.Compiler.Service >= 25.0.1 
-nuget Dotnet.ProjInfo
+nuget Dotnet.ProjInfo ~> 0.31.0
 nuget FSharp.Core ~> 4.3.4
 nuget nunit
 nuget NUnit3TestAdapter

--- a/paket.lock
+++ b/paket.lock
@@ -1,8 +1,8 @@
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Dotnet.ProjInfo (0.20)
-      FSharp.Core (>= 4.0.0.1) - restriction: >= net45
-      FSharp.Core (>= 4.1.18) - restriction: && (< net45) (>= netstandard2.0)
+    Dotnet.ProjInfo (0.31)
+      FSharp.Core (>= 4.3.4) - restriction: || (>= net461) (>= netstandard2.0)
+      System.ValueTuple (>= 4.4) - restriction: || (>= net461) (>= netstandard2.0)
     FParsec (1.0.3)
       FSharp.Core (>= 4.0.0.1) - restriction: >= net40
       FSharp.Core (>= 4.2.3) - restriction: && (< net40) (>= netstandard1.6)

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     
     <Title>FSharpLint.Core</Title>

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/FSharpLint.FunctionalTest/FSharpLint.FunctionalTest.fsproj
+++ b/tests/FSharpLint.FunctionalTest/FSharpLint.FunctionalTest.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
using `FSharpLint.Core` targeting `net` fails

```
Error Message:
 System.TypeInitializationException : The type initializer for 'FSharpLint.Framework.Configuration' threw an exception.
  ----> System.TypeInitializationException : The type initializer for '<StartupCode$FSharpLint-Core>.$Configuration' threw an exception.
  ----> System.IO.FileLoadException : Could not load file or assembly 'FParsecCS, Version=1.0.3.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
```

That's caused by bad packaging of FParsec.

As workaround (and as best practice), multitarget `FSharpLint.Core` for both `net` and `netstandard`.

Bump version of `Dotnet.ProjInfo` because v0.31 use the same api for .NET and .NET Standard, to minimize changes

ref https://github.com/stephan-tolksdorf/fparsec/issues/34
ref https://github.com/fsharp/FsAutoComplete/issues/336