### PR TITLE
Improve tuple item spacing check

### DIFF
--- a/ConfigurationSchema.xsd
+++ b/ConfigurationSchema.xsd
@@ -288,6 +288,7 @@
               </xs:complexType>
             </xs:element>
             <xs:element name="TupleCommaSpacing" maxOccurs="1" minOccurs="0" type="Enabled" />
+			<xs:element name="TupleIndentation" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TupleParentheses" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="TypePrefixing" maxOccurs="1" minOccurs="0" type="Enabled" />
             <xs:element name="PatternMatchClausesOnNewLine" maxOccurs="1" minOccurs="0" type="Enabled" />

--- a/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
+++ b/src/FSharpLint.Core/DefaultConfiguration.FSharpLint
@@ -442,6 +442,9 @@
         <TupleCommaSpacing>
           <Enabled>true</Enabled>
         </TupleCommaSpacing>
+        <TupleIndentation>
+          <Enabled>true</Enabled>
+        </TupleIndentation>       
         <TupleParentheses>
           <Enabled>true</Enabled>
         </TupleParentheses>

--- a/src/FSharpLint.Core/Rules/Formatting.fs
+++ b/src/FSharpLint.Core/Rules/Formatting.fs
@@ -93,8 +93,6 @@ module Formatting =
 
             if isEnabled && isSuppressed ruleName |> not then
                 match parentNode with
-                | Some (AstNode.Expression (SynExpr.App (funcExpr=(SynExpr.Ident ident)))) when ident.idText = "op_ColonColon" ->
-                    ()
                 | Some (AstNode.Expression (SynExpr.Paren _)) ->
                     ()
                 | _ ->
@@ -465,9 +463,14 @@ module Formatting =
                 TypedItemSpacing.checkTypedItemSpacing args range (isSuppressed i) 
             | AstNode.Expression (SynExpr.Tuple (exprs, _, tupleRange)) ->
                 let parentNode = AbstractSyntaxArray.getBreadcrumbs 1 syntaxArray skipArray i |> List.tryHead
-                TupleFormatting.checkTupleHasParentheses args parentNode tupleRange (isSuppressed i)
-                TupleFormatting.checkTupleCommaSpacing args exprs tupleRange (isSuppressed i)
-                TupleFormatting.checkTupleIndentation args exprs (isSuppressed i)
+                match parentNode with
+                | Some (AstNode.Expression (SynExpr.App (funcExpr=(SynExpr.Ident ident)))) when ident.idText = "op_ColonColon" ->
+                    // cons operator is parsed as tuple, ignore it for tuple checking
+                    ()
+                | _ ->
+                    TupleFormatting.checkTupleHasParentheses args parentNode tupleRange (isSuppressed i)
+                    TupleFormatting.checkTupleCommaSpacing args exprs tupleRange (isSuppressed i)
+                    TupleFormatting.checkTupleIndentation args exprs (isSuppressed i)
             | AstNode.Expression (SynExpr.Match (_, _, clauses, _, range))
             | AstNode.Expression (SynExpr.MatchLambda (_, _, clauses, _, range)) 
             | AstNode.Expression (SynExpr.TryWith (_, _, clauses, range, _, _, _)) as node ->

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -255,6 +255,9 @@
   <data name="RulesFormattingTupleCommaSpacingError" xml:space="preserve">
     <value>Comma in tuple instantiation should be followed by single space.</value>
   </data>
+   <data name="RulesFormattingTupleIndentationError" xml:space="preserve">
+    <value>Sub-expressions of tuple on different lines should have consistent indentation.</value>
+  </data> 
   <data name="RulesFormattingTupleParenthesesError" xml:space="preserve">
     <value>Use parentheses for tuple instantiation.</value>
   </data>

--- a/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
@@ -21,6 +21,7 @@ let config typedItemSpacingStyle =
             { Rules = Map.ofList 
                 [ ("TypedItemSpacing", typedItemSpacingConfig typedItemSpacingStyle)
                   ("TupleCommaSpacing", ruleEnabled)
+                  ("TupleIndentation", ruleEnabled)
                   ("TupleParentheses", ruleEnabled)
                   ("TypePrefixing", ruleEnabled)
                   ("ModuleDeclSpacing", ruleEnabled)
@@ -331,6 +332,30 @@ module Program
 
 let x = (
     1, 2,
+    3)""")
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Error for tuple with newlines and inconsistent indentation``() =
+        this.Parse("""
+module Program
+
+let x = (
+    1,
+        2,
+        3)""")
+
+        Assert.IsTrue(this.ErrorExistsAt(5, 4))
+
+    [<Test>]
+    member this.``No error for tuple with newlines and consistent indentation``() =
+        this.Parse("""
+module Program
+
+let x = (
+    1,
+    2,
     3)""")
 
         Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestFormattingRules.fs
@@ -272,7 +272,7 @@ module Program
 
 let x = (1,2)""")
 
-        Assert.IsTrue(this.ErrorExistsAt(4, 9))
+        Assert.IsTrue(this.ErrorExistsAt(4, 10))
 
     [<Test>]
     member this.``Quickfix for tuple instantiation without space after comma``() =
@@ -297,7 +297,7 @@ module Program
 
 let x = (1,  2)""")
 
-        Assert.IsTrue(this.ErrorExistsAt(4, 9))
+        Assert.IsTrue(this.ErrorExistsAt(4, 10))
 
     [<Test>]
     member this.``Quickfix for tuple instantiation with two spaces after comma``() =
@@ -321,6 +321,17 @@ let x = (1, 2)"""
 module Program
 
 let x = (1, 2)""")
+
+        Assert.IsTrue(this.NoErrorsExist)
+        
+    [<Test>]
+    member this.``No error for tuple instantiation with newline after comma``() =
+        this.Parse("""
+module Program
+
+let x = (
+    1, 2,
+    3)""")
 
         Assert.IsTrue(this.NoErrorsExist)
 


### PR DESCRIPTION
Fixes #301.

- Make tuple spacing check simpler and more robust
- Handle newlines after commas in tuple
- Add new rule `TupleIndentation` which checks that a tuple split across multiple lines has consistent indentation