### PR TITLE
Ignore special op_ prefixed members in name convention analyser

### DIFF
--- a/src/FSharpLint.Core/Rules/NameConventions.fs
+++ b/src/FSharpLint.Core/Rules/NameConventions.fs
@@ -354,8 +354,11 @@ module NameConventions =
     let private checkMember checkRule rules _ = function
         | SynPat.LongIdent(longIdent, _, _, _, _, _) ->
             match List.tryLast longIdent.Lid with
-            | Some(ident) -> checkRule rules.MemberNames ident
+            | Some(ident) when ident.idText.StartsWith "op_" -> 
+                // Ignore members prefixed with op_, they are a special case used for operator overloading.
+                []
             | None -> []
+            | Some(ident) -> checkRule rules.MemberNames ident
         | SynPat.Named(_, ident, _, _, _)
         | SynPat.OptionalVal(ident, _) ->
             checkRule rules.ParameterNames ident

--- a/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNameConventionRules.fs
@@ -1399,3 +1399,16 @@ let SomeCamel WithCamel.YesCamel = 12  """
         this.Parse source
         
         this.AssertNoWarnings()
+
+    /// Regression test for: https://github.com/fsprojects/FSharpLint/issues/323
+    [<Test>]
+    member this.``Special op_ prefixed members do not cause errors`` () =
+        let source = """
+type X = X of int
+with
+    static member op_Explicit(X x) = x
+    static member op_Implicit(X x) = x
+"""
+
+        this.Parse source
+        this.AssertNoWarnings()


### PR DESCRIPTION
Members prefixed with `op_` are generally used for [operator overloading](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/operator-overloading). For these member, we should ignore any name convention rules.