### PR TITLE
Fix default configuration loader and add test for linting project

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.11.1 - May 14 2019
+
+* Fix issue in loading default configuration
+
 ##### 0.11.0 - May 14 2019
 
 * Add ability to disable previously defined hints

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -109,7 +109,9 @@
     <Compile Include="Application\XmlConfiguration.fs" />
     <Compile Include="Application/Lint.fsi" />
     <Compile Include="Application\Lint.fs" />
-    <EmbeddedResource Include="../FSharpLint.Core/DefaultConfiguration.json" />
+    <EmbeddedResource Include="../FSharpLint.Core/DefaultConfiguration.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="../FSharpLint.Core/Text.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -56,3 +56,16 @@ module TestApi =
             
             Assert.Less(result, 250)
             System.Console.WriteLine(sprintf "Average runtime of linter on parsed file: %d (milliseconds)."  result)
+
+        [<Test>]
+        member __.``Lint project``() =
+            let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject"
+            let projectFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.fsproj"
+
+            let result = lintProject OptionalLintParameters.Default projectFile
+
+            match result with
+            | LintResult.Success warnings ->
+                Assert.AreEqual(9, warnings.Length)
+            | LintResult.Failure _ ->
+                Assert.True(false)


### PR DESCRIPTION
There was an issue loading the default config since the change to JSON configuration. Added a functional test to test project linting, based on the existing console application test.