### PR TITLE
Ignore active patterns in PublicValues naming conventions rule

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -9,6 +9,10 @@ open FSharpLint.Rules.Helper.Naming
 let private getValueOrFunctionIdents typeChecker isPublic pattern =
     let checkNotUnionCase ident =
         typeChecker |> Option.map (fun checker -> isNotUnionCase checker ident)
+    
+    let isNotActivePattern (ident:Ident) =
+        ident.idText.StartsWith("|")
+        |> not
 
     match pattern with
     | SynPat.LongIdent(longIdent, _, _, _, _, _) ->
@@ -18,7 +22,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if isPublic then
+            if isPublic && isNotActivePattern ident then
                 (ident, ident.idText, checkNotUnionCase)
                 |> Array.singleton
             else

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -58,4 +58,14 @@ type SingleCaseDU = SingleCaseDU of int
 
 let (SingleCaseDU myInt) = (SingleCaseDU 5)""")
         
-        this.AssertNoWarnings() 
+        this.AssertNoWarnings()
+        
+    [<Test>]
+    member this.``ActivePatternDoesNotGenerateWarning`` () =
+         this.Parse("""
+let (|Empty|_|) str =
+    match str with
+    | "" -> Some Empty
+    | _ -> None""")
+
+         this.AssertNoWarnings()       


### PR DESCRIPTION
Fixes #357.