### PR TITLE
Added fix for parsing solutions with subfolders

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -559,7 +559,7 @@ module Lint =
         let projectsInSolution =
             File.ReadAllText(solutionFilePath)
             |> String.toLines
-            |> Array.filter (fun (s, _, _) ->  s.StartsWith("Project"))
+            |> Array.filter (fun (s, _, _) ->  s.StartsWith("Project") && s.Contains(".fsproj"))
             |> Array.map (fun (s, _, _) ->
                 let endIndex = s.IndexOf(".fsproj") + 7
                 let startIndex = s.IndexOf(",") + 1


### PR DESCRIPTION
When running FSharpLint on a solution file (via `-sol`) that contains subfolders, the application outputs an error and a stack trace:

```
Lint failed while analysing solution .\FSharpLint.sln.
Failed with: Length cannot be less than zero.
Parameter name: length
Stack trace:   at System.String.Substring(Int32 startIndex, Int32 length)
   at FSharpLint.Application.Lint.mapping@1-2(String tupledArg0, Int32 tupledArg1, Boolean tupledArg2) in C:\projects\fsharplint-231\src\FSharpLint.Core\Application\Lint.fs:line 567
   at FSharpLint.Application.Lint.lintSolution(OptionalLintParameters optionalParams, String solutionFilePath) in C:\projects\fsharplint-231\src\FSharpLint.Core\Application\Lint.fs:line 563
   at FSharpLint.Console.Program.startWithArguments@171.Invoke(Argument arg) in C:\projects\fsharplint-231\src\FSharpLint.Console\Program.fs:line 181
```

The reason for this is that projects and folders in  a solution file are almost identical. An example of this from FSharpLint.sln itself:

```
Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1CD44876-BCDC-4C93-9DC2-C45244BD62AE}"
EndProject
Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpLint.Console", "src\FSharpLint.Console\FSharpLint.Console.fsproj", "{AC24094C-4AB5-4A6B-8430-3D21EF788AEC}"
EndProject
```

The top entry is for a folder named tests, and the bottom is for an F# project. FSharpLint considers them both as project files, so when it tries to find the project path based on the `.fsproj` extension it cannot for the test folder.

This fix just adds another check on the line filters, to make sure that only lines containing `.fsproj` in the solution are considered.