### PR TITLE
Add -c flag for specifying release configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.12.7 - January 7 2020
+
+* Add `-c` flag for specifying MSBuild release configuration
+
 ##### 0.12.6 - December 5 2019
 
 * Update FCS to 33.0 [@baronfel]

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -76,7 +76,9 @@ module Lint =
           /// This function will be called every time the linter finds a broken rule.
           ReceivedWarning: (LintWarning.Warning -> unit) option 
           
-          ReportLinterProgress: (ProjectProgress -> unit) option }
+          ReportLinterProgress: (ProjectProgress -> unit) option
+
+          ReleaseConfiguration : string option }
 
         static member Default: OptionalLintParameters
 

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -68,7 +68,7 @@ module TestApi =
 
             match result with
             | LintResult.Success warnings ->
-                Assert.AreEqual(9, warnings.Length)
+                Assert.AreEqual(15, warnings.Length)
             | LintResult.Failure _ ->
                 Assert.True(false)
 
@@ -81,7 +81,7 @@ module TestApi =
 
             match result with
             | LintResult.Success warnings ->
-                Assert.AreEqual(9, warnings.Length)
+                Assert.AreEqual(15, warnings.Length)
             | LintResult.Failure _ ->
                 Assert.True(false)               
                 

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -68,7 +68,7 @@ module TestApi =
 
             match result with
             | LintResult.Success warnings ->
-                Assert.AreEqual(15, warnings.Length)
+                Assert.AreEqual(9, warnings.Length)
             | LintResult.Failure _ ->
                 Assert.True(false)
 
@@ -81,7 +81,7 @@ module TestApi =
 
             match result with
             | LintResult.Success warnings ->
-                Assert.AreEqual(15, warnings.Length)
+                Assert.AreEqual(9, warnings.Length)
             | LintResult.Failure _ ->
                 Assert.True(false)               
                 

--- a/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
+++ b/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
@@ -61,7 +61,11 @@ module Tests =
           "FL0065: `List.fold ( + ) 0 x` might be able to be refactored into `List.sum x`."
           "FL0065: `a <> true` might be able to be refactored into `not a`."
           "FL0065: `x = null` might be able to be refactored into `isNull x`."
-          "FL0065: `List.head (List.sort x)` might be able to be refactored into `List.min x`." ]
+          "FL0065: `List.head (List.sort x)` might be able to be refactored into `List.min x`."
+          "FL0001: Comma in tuple instantiation should be followed by single space."
+          "FL0003: Use parentheses for tuple instantiation."
+          "FL0059: Invalid indentation."
+          "FL0063: Found trailing whitespace line at end of file." ]
         
     [<TestFixture(Category = "Acceptance Tests")>]
     type TestConsoleApplication() =
@@ -106,6 +110,21 @@ module Tests =
             Assert.AreEqual(expectedErrors, errors, 
                 "Did not find the following expected errors: [" + String.concat "," expectedMissing + "]\n" + 
                 "Found the following unexpected warnings: [" + String.concat "," notExpected + "]")
+            
+        [<Test>]
+        member __.FunctionalTestConsoleApplicationReleaseMode() = 
+            let projectFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.fsproj"
+            let arguments = sprintf "-f %s -c Release" projectFile
+
+            let output = dotnetFslint arguments
+            let errors = getErrorsFromOutput output
+            
+            let expectedMissing = Set.difference expectedErrors errors
+            let notExpected = Set.difference errors expectedErrors
+
+            Assert.AreEqual(expectedErrors, errors, 
+                "Did not find the following expected errors: [" + String.concat "," expectedMissing + "]\n" + 
+                "Found the following unexpected warnings: [" + String.concat "," notExpected + "]")           
             
         [<Test>]
         member __.FunctionalTestConsoleApplicationSolution() = 

--- a/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
+++ b/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
@@ -61,11 +61,7 @@ module Tests =
           "FL0065: `List.fold ( + ) 0 x` might be able to be refactored into `List.sum x`."
           "FL0065: `a <> true` might be able to be refactored into `not a`."
           "FL0065: `x = null` might be able to be refactored into `isNull x`."
-          "FL0065: `List.head (List.sort x)` might be able to be refactored into `List.min x`."
-          "FL0001: Comma in tuple instantiation should be followed by single space."
-          "FL0003: Use parentheses for tuple instantiation."
-          "FL0059: Invalid indentation."
-          "FL0063: Found trailing whitespace line at end of file." ]
+          "FL0065: `List.head (List.sort x)` might be able to be refactored into `List.min x`." ]
         
     [<TestFixture(Category = "Acceptance Tests")>]
     type TestConsoleApplication() =


### PR DESCRIPTION
Adds support for the `-c` flag for specifying the release configuration to use for MSBuild (e.g. `Debug`, `Release`).