### PR TITLE
Pass build configuration to dotnet proj info

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.12.8 - January 13 2020
+
+* Pass release configuration to dotnet proj info
+
 ##### 0.12.7 - January 7 2020
 
 * Add `-c` flag for specifying MSBuild release configuration

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -388,7 +388,7 @@ module Lint =
             let msbuildExec = Dotnet.ProjInfo.Inspect.dotnetMsbuild runCmd
         
             projectFilePath
-            |> Dotnet.ProjInfo.Inspect.getProjectInfos ignore msbuildExec [Dotnet.ProjInfo.Inspect.getFscArgs; Dotnet.ProjInfo.Inspect.getResolvedP2PRefs] []
+            |> Dotnet.ProjInfo.Inspect.getProjectInfos ignore msbuildExec [Dotnet.ProjInfo.Inspect.getFscArgs; Dotnet.ProjInfo.Inspect.getResolvedP2PRefs] msBuildParams
             
         match msBuildResults with
         | Result.Ok [getFscArgsResult; getP2PRefsResult] ->

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -84,6 +84,19 @@ module TestApi =
                 Assert.AreEqual(9, warnings.Length)
             | LintResult.Failure _ ->
                 Assert.True(false)               
+               
+        [<Test>]
+        member __.``Lint solution with release config``() =
+            let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject"
+            let solutionFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.sln"
+
+            let result = lintSolution { OptionalLintParameters.Default with ReleaseConfiguration = Some "Release" } solutionFile
+
+            match result with
+            | LintResult.Success warnings ->
+                Assert.AreEqual(9, warnings.Length)
+            | LintResult.Failure _ ->
+                Assert.True(false)                              
                 
 #if NETCOREAPP // GetRelativePath is netcore-only
         [<Test>]


### PR DESCRIPTION
Pass the received release configuration into the build call for dotnet proj info.