### PR TITLE
Added a sample on how to inhibit the FS0050 warning

### DIFF
--- a/docs-gen/markdown/NameConventions.md
+++ b/docs-gen/markdown/NameConventions.md
@@ -35,3 +35,14 @@ Each of the following rules targets a different kind of element.
 - ActivePatternNames - FS0048
 - PublicValuesNames - FS0049
 - NonPublicValuesNames - FS0050
+
+### Example
+
+Check the sample how to ignore the FS0050 warnings:
+
+        let willShowWarning () =
+        let WithWarning = None
+        [<System.Diagnostics.CodeAnalysis.SuppressMessage("*", "NonPublicValuesNames")>]
+        let NoWarning = None
+        NoWarning, WithWarning
+


### PR DESCRIPTION
Hi! I added a sample on how to inhibit a naming warning on the page that will most likely will be hit by the search engines.

**NOTE: Didn't build the solution (so the html files were not regenerated) because I don't have installed the required SDK(switching the global.json to 3.1 didn't help).**

 If you consider that this will help, please do the required step :)

Cheers