### PR TITLE
Fix bug in getting substring of line for token

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.13.3 - February 25 2020
+
+* Fix for suppression comment parsing
+
 ##### 0.13.2 - February 25 2020
 
 * Remove support for multiple overriding configs

--- a/src/FSharpLint.Core/Framework/ParseFile.fs
+++ b/src/FSharpLint.Core/Framework/ParseFile.fs
@@ -140,7 +140,8 @@ module ParseFile =
     let tokenizeLine (tokenizer:FSharpLineTokenizer) (line : string) initialState =
         let rec helper (state, tokens) =
             match tokenizer.ScanToken(state) with
-            | (Some tok, state) -> helper (state, (line.Substring(tok.LeftColumn, tok.FullMatchedLength), tok) :: tokens)
+            | (Some tok, state) ->
+                helper (state, (line.Substring(tok.LeftColumn, tok.RightColumn - tok.LeftColumn + 1), tok) :: tokens)
             | (None, state) -> (state, tokens)
 
         let (finalState, tokens) = helper (initialState, [])


### PR DESCRIPTION
It seems sometimes the `FullMatchedLength` property of the token is sometimes incorrect (or it is being used incorrectly). For example, on the line `#if NETCOREAPP2_0`, the whitespace token between the `#if` and the rest had a length of `17`, when it should be `1`. This updates the suppression token parser to use left and right column for the substring.

Fixes #386 