### PR TITLE
Add `globals` section to config for shared settings

### DIFF
--- a/docs-gen/markdown/MSBuildTask.md
+++ b/docs-gen/markdown/MSBuildTask.md
@@ -2,7 +2,7 @@
 
 FSharpLint can be run as an MSBuild task; this will result in lint warnings showing up in your IDE (Visual Studio/Rider).
 
-To set this up, first [install the FSharpLint dotnet tool](ConsoleApplication).
+To set this up, first [install the FSharpLint dotnet tool](DotnetTool).
 
 Then, you can add the following to any of your projects to run linting after build completion for that project:
 

--- a/docs-gen/markdown/Rules.md
+++ b/docs-gen/markdown/Rules.md
@@ -1,5 +1,20 @@
 # Rules
 
+## Global Configuration
+
+In addition to the configuration available for each rule, there are some settings which are defined globally to maintain consistency across
+multiple rules. These are defind in the `globals` object in the base of the configuration file. The rule pages below point out any global
+setting that each rule depends on. The config is as follows, but can be completely omitted to use defaults:
+
+  [lang=javascript]
+    {
+      "globals": {
+        "numIndentationSpaces": 4 // number of spaces used for indentation
+      }
+    }
+
+## Rule Lists
+
 The following rules can be specified for linting.
 
 - [TupleCommaSpacing (FL0001)](rules/FL0001.html)
@@ -67,3 +82,4 @@ The following rules can be specified for linting.
 - [TrailingNewLineInFile (FL0063)](rules/FL0063.html)
 - [NoTabCharacters (FL0064)](rules/FL0064.html)
 - [Hints (FL0065)](rules/FL0065.html)
+

--- a/docs-gen/markdown/rules/FL0001.md
+++ b/docs-gen/markdown/rules/FL0001.md
@@ -16,7 +16,7 @@ Add a space after tuple commas.
 
 	[lang=javascript]
     {
-        "tupleCommaSpacing": { 
+        "tupleCommaSpacing": {
             "enabled": false
         }
     }

--- a/docs-gen/markdown/rules/FL0006.md
+++ b/docs-gen/markdown/rules/FL0006.md
@@ -14,9 +14,11 @@ Update pattern match clauses to have consistent indentation.
 
 ## Rule Settings
 
+Uses the `numIndentationSpaces` global setting.
+
 	[lang=javascript]
     {
-        "patternMatchClauseIndentation": { 
+        "patternMatchClauseIndentation": {
             "enabled": false
         }
     }

--- a/docs-gen/markdown/rules/FL0007.md
+++ b/docs-gen/markdown/rules/FL0007.md
@@ -14,9 +14,11 @@ Update pattern match expressions to have consistent indentation.
 
 ## Rule Settings
 
+Uses the `numIndentationSpaces` global setting.
+
 	[lang=javascript]
     {
-        "patternMatchExpressionIndentation": { 
+        "patternMatchExpressionIndentation": {
             "enabled": false
         }
     }

--- a/docs-gen/markdown/rules/FL0012.md
+++ b/docs-gen/markdown/rules/FL0012.md
@@ -14,9 +14,11 @@ Update union definition to have correct formatting as specified in linked guide 
 
 ## Rule Settings
 
+Uses the `numIndentationSpaces` global setting.
+
 	[lang=javascript]
     {
-        "unionDefinitionIndentation": { 
+        "unionDefinitionIndentation": {
             "enabled": false
         }
     }

--- a/docs-gen/markdown/rules/FL0059.md
+++ b/docs-gen/markdown/rules/FL0059.md
@@ -1,0 +1,24 @@
+# Indentation (FL0059)
+
+## Cause
+
+Inconsistent indentation in file.
+
+## Rationale
+
+Readability.
+
+## How To Fix
+
+Update file to use consistent amount of spaces for indentation.
+
+## Rule Settings
+
+Uses the `numIndentationSpaces` global setting.
+
+	[lang=javascript]
+    {
+        "indentation": {
+            "enabled": false
+        }
+    }

--- a/docs/Rules.html
+++ b/docs/Rules.html
@@ -28,6 +28,17 @@
       <div class="row">
         <div class="span9" id="main">
           <h1><a name="Rules" class="anchor" href="#Rules">Rules</a></h1>
+<h2><a name="Global-Configuration" class="anchor" href="#Global-Configuration">Global Configuration</a></h2>
+<p>In addition to the configuration available for each rule, there are some settings which are defined globally to maintain consistency across
+multiple rules. These are defind in the <code>globals</code> object in the base of the configuration file. The rule pages below point out any global
+setting that each rule depends on. The config is as follows, but can be completely omitted to use defaults:</p>
+<p>[lang=javascript]
+{
+"globals": {
+"numIndentationSpaces": 4 // number of spaces used for indentation
+}
+}</p>
+<h2><a name="Rule-Lists" class="anchor" href="#Rule-Lists">Rule Lists</a></h2>
 <p>The following rules can be specified for linting.</p>
 <ul>
 <li><a href="rules/FL0001.html">TupleCommaSpacing (FL0001)</a></li>

--- a/docs/rules/FL0001.html
+++ b/docs/rules/FL0001.html
@@ -42,7 +42,7 @@
 <span class="l">5: </span>
 </pre></td>
 <td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
-    <span class="s">"tupleCommaSpacing"</span>: { 
+    <span class="s">"tupleCommaSpacing"</span>: {
         <span class="s">"enabled"</span>: <span class="k">false</span>
     }
 }

--- a/docs/rules/FL0006.html
+++ b/docs/rules/FL0006.html
@@ -35,6 +35,7 @@
 <h2><a name="How-To-Fix" class="anchor" href="#How-To-Fix">How To Fix</a></h2>
 <p>Update pattern match clauses to have consistent indentation.</p>
 <h2><a name="Rule-Settings" class="anchor" href="#Rule-Settings">Rule Settings</a></h2>
+<p>Uses the <code>numIndentationSpaces</code> global setting.</p>
 <table class="pre"><tr><td class="lines"><pre class="fssnip"><span class="l">1: </span>
 <span class="l">2: </span>
 <span class="l">3: </span>
@@ -42,7 +43,7 @@
 <span class="l">5: </span>
 </pre></td>
 <td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
-    <span class="s">"patternMatchClauseIndentation"</span>: { 
+    <span class="s">"patternMatchClauseIndentation"</span>: {
         <span class="s">"enabled"</span>: <span class="k">false</span>
     }
 }

--- a/docs/rules/FL0007.html
+++ b/docs/rules/FL0007.html
@@ -35,6 +35,7 @@
 <h2><a name="How-To-Fix" class="anchor" href="#How-To-Fix">How To Fix</a></h2>
 <p>Update pattern match expressions to have consistent indentation.</p>
 <h2><a name="Rule-Settings" class="anchor" href="#Rule-Settings">Rule Settings</a></h2>
+<p>Uses the <code>numIndentationSpaces</code> global setting.</p>
 <table class="pre"><tr><td class="lines"><pre class="fssnip"><span class="l">1: </span>
 <span class="l">2: </span>
 <span class="l">3: </span>
@@ -42,7 +43,7 @@
 <span class="l">5: </span>
 </pre></td>
 <td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
-    <span class="s">"patternMatchExpressionIndentation"</span>: { 
+    <span class="s">"patternMatchExpressionIndentation"</span>: {
         <span class="s">"enabled"</span>: <span class="k">false</span>
     }
 }

--- a/docs/rules/FL0012.html
+++ b/docs/rules/FL0012.html
@@ -35,6 +35,7 @@
 <h2><a name="How-To-Fix" class="anchor" href="#How-To-Fix">How To Fix</a></h2>
 <p>Update union definition to have correct formatting as specified in linked guide (indent <code>|</code> by 4 spaces).</p>
 <h2><a name="Rule-Settings" class="anchor" href="#Rule-Settings">Rule Settings</a></h2>
+<p>Uses the <code>numIndentationSpaces</code> global setting.</p>
 <table class="pre"><tr><td class="lines"><pre class="fssnip"><span class="l">1: </span>
 <span class="l">2: </span>
 <span class="l">3: </span>
@@ -42,7 +43,7 @@
 <span class="l">5: </span>
 </pre></td>
 <td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
-    <span class="s">"unionDefinitionIndentation"</span>: { 
+    <span class="s">"unionDefinitionIndentation"</span>: {
         <span class="s">"enabled"</span>: <span class="k">false</span>
     }
 }

--- a/docs/rules/FL0059.html
+++ b/docs/rules/FL0059.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Running as MSBuildTask
+    <title>Indentation (FL0059)
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Matthew Mcveigh">
@@ -27,27 +27,27 @@
       <hr />
       <div class="row">
         <div class="span9" id="main">
-          <h1><a name="Running-as-MSBuildTask" class="anchor" href="#Running-as-MSBuildTask">Running as MSBuildTask</a></h1>
-<p>FSharpLint can be run as an MSBuild task; this will result in lint warnings showing up in your IDE (Visual Studio/Rider).</p>
-<p>To set this up, first <a href="DotnetTool">install the FSharpLint dotnet tool</a>.</p>
-<p>Then, you can add the following to any of your projects to run linting after build completion for that project:</p>
+          <h1><a name="Indentation-FL0059" class="anchor" href="#Indentation-FL0059">Indentation (FL0059)</a></h1>
+<h2><a name="Cause" class="anchor" href="#Cause">Cause</a></h2>
+<p>Inconsistent indentation in file.</p>
+<h2><a name="Rationale" class="anchor" href="#Rationale">Rationale</a></h2>
+<p>Readability.</p>
+<h2><a name="How-To-Fix" class="anchor" href="#How-To-Fix">How To Fix</a></h2>
+<p>Update file to use consistent amount of spaces for indentation.</p>
+<h2><a name="Rule-Settings" class="anchor" href="#Rule-Settings">Rule Settings</a></h2>
+<p>Uses the <code>numIndentationSpaces</code> global setting.</p>
 <table class="pre"><tr><td class="lines"><pre class="fssnip"><span class="l">1: </span>
 <span class="l">2: </span>
 <span class="l">3: </span>
 <span class="l">4: </span>
 <span class="l">5: </span>
-<span class="l">6: </span>
-<span class="l">7: </span>
 </pre></td>
-<td class="snippet"><pre class="fssnip highlighted"><code lang="xml"><span class="k">&lt;</span><span class="i">Target</span> <span class="o">Name</span><span class="k">="FSharpLint"</span> <span class="o">AfterTargets</span><span class="k">="AfterBuild"</span><span class="k">&gt;</span>
- <span class="k">&lt;</span><span class="i">Exec</span>
-   <span class="o">Command</span><span class="k">="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"</span>
-   <span class="o">ConsoleToMsBuild</span><span class="k">="true"</span>
-   <span class="o">IgnoreExitCode</span><span class="k">="true"</span>
- <span class="k">/&gt;</span>
-<span class="k">&lt;/</span><span class="i">Target</span><span class="k">&gt;</span>
+<td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
+    <span class="s">"indentation"</span>: {
+        <span class="s">"enabled"</span>: <span class="k">false</span>
+    }
+}
 </code></pre></td></tr></table>
-<p>If you would like to enable linting for all projects, you can add the above target to either a <code>Directory.Build.props</code> or <code>Directory.Build.targets</code> file in the root of your repository. This will add the target to all files. See <a href="https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019">here</a> for more info</p>
 
           
         </div>

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -350,7 +350,6 @@ type GlobalConfig = {
 
 type Configuration =
     { ``global`` : GlobalConfig option
-      ignoreFiles : string [] option
       // Deprecated grouped configs. TODO: remove in next major release
       /// DEPRECATED, provide formatting rules at root level.
       formatting : FormattingConfig option
@@ -417,7 +416,7 @@ type Configuration =
       WildcardNamedWithAsPattern : EnabledConfig option
       UselessBinding : EnabledConfig option
       TupleOfWildcards : EnabledConfig option
-      Indentation : RuleConfig<Indentation.Config> option
+      Indentation : EnabledConfig option
       MaxCharactersOnLine : RuleConfig<MaxCharactersOnLine.Config> option
       TrailingWhitespaceOnLine : RuleConfig<TrailingWhitespaceOnLine.Config> option
       MaxLinesInFile : RuleConfig<MaxLinesInFile.Config> option
@@ -535,9 +534,9 @@ type LineRules =
       IndentationRule : RuleMetadata<IndentationRuleConfig> option }
 
 type LoadedRules =
-    { globalConfig : Rules.GlobalRuleConfig
-      astNodeRules : RuleMetadata<AstNodeRuleConfig> []
-      lineRules : LineRules
+    { GlobalConfig : Rules.GlobalRuleConfig
+      AstNodeRules : RuleMetadata<AstNodeRuleConfig> []
+      LineRules : LineRules
       DeprecatedRules : Rule [] }
 
 let getGlobalConfig (globalConfig:GlobalConfig option) =
@@ -627,7 +626,7 @@ let flattenConfig (config:Configuration) =
             config.WildcardNamedWithAsPattern |> Option.bind (constructRuleIfEnabled WildcardNamedWithAsPattern.rule)
             config.UselessBinding |> Option.bind (constructRuleIfEnabled UselessBinding.rule)
             config.TupleOfWildcards |> Option.bind (constructRuleIfEnabled TupleOfWildcards.rule)
-            config.Indentation |> Option.bind (constructRuleWithConfig Indentation.rule)
+            config.Indentation |> Option.bind (constructRuleIfEnabled Indentation.rule)
             config.MaxCharactersOnLine |> Option.bind (constructRuleWithConfig MaxCharactersOnLine.rule)
             config.TrailingWhitespaceOnLine |> Option.bind (constructRuleWithConfig TrailingWhitespaceOnLine.rule)
             config.MaxLinesInFile |> Option.bind (constructRuleWithConfig MaxLinesInFile.rule)
@@ -651,10 +650,10 @@ let flattenConfig (config:Configuration) =
         | IndentationRule rule -> indentationRule <- Some rule
         | NoTabCharactersRule rule -> noTabCharactersRule <- Some rule)
 
-    { LoadedRules.globalConfig = getGlobalConfig config.``global``
+    { LoadedRules.GlobalConfig = getGlobalConfig config.``global``
       DeprecatedRules = deprecatedAllRules
-      astNodeRules = astNodeRules.ToArray()
-      lineRules =
-          { genericLineRules = lineRules.ToArray()
-            indentationRule = indentationRule
-            noTabCharactersRule = noTabCharactersRule } }
+      AstNodeRules = astNodeRules.ToArray()
+      LineRules =
+          { GenericLineRules = lineRules.ToArray()
+            IndentationRule = indentationRule
+            NoTabCharactersRule = noTabCharactersRule } }

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -329,7 +329,7 @@ type TypographyConfig =
 with
     member this.Flatten() =
          [|
-            this.indentation |> Option.bind (constructRuleWithConfig Indentation.rule) |> Option.toArray
+            this.indentation |> Option.bind (constructRuleIfEnabled Indentation.rule) |> Option.toArray
             this.maxCharactersOnLine |> Option.bind (constructRuleWithConfig MaxCharactersOnLine.rule) |> Option.toArray
             this.trailingWhitespaceOnLine |> Option.bind (constructRuleWithConfig TrailingWhitespaceOnLine.rule) |> Option.toArray
             this.maxLinesInFile |> Option.bind (constructRuleWithConfig MaxLinesInFile.rule) |> Option.toArray

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -116,7 +116,7 @@ module Lint =
         { IndentationRuleContext : Map<int,bool*int>
           NoTabCharactersRuleContext : (string * Range.range) list }
 
-    let runAstNodeRules (rules:RuleMetadata<AstNodeRuleConfig> []) (globalConfig : Rules.GlobalRuleConfig) typeCheckResults (filePath:string) (fileContent:string) syntaxArray skipArray =
+    let runAstNodeRules (rules:RuleMetadata<AstNodeRuleConfig> []) (globalConfig:Rules.GlobalRuleConfig) typeCheckResults (filePath:string) (fileContent:string) syntaxArray skipArray =
         let mutable indentationRuleState = Map.empty
         let mutable noTabCharactersRuleState = List.empty
 
@@ -151,7 +151,7 @@ module Lint =
         rules |> Array.iter (fun rule -> rule.RuleConfig.Cleanup())
         (astNodeSuggestions, context)
 
-    let runLineRules (lineRules:Configuration.LineRules) (globalConfig : Rules.GlobalRuleConfig) (filePath:string) (fileContent:string) (context:Context) =
+    let runLineRules (lineRules:Configuration.LineRules) (globalConfig:Rules.GlobalRuleConfig) (filePath:string) (fileContent:string) (context:Context) =
         fileContent
         |> String.toLines
         |> Array.collect (fun (line, lineNumber, isLastLine) ->

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -116,7 +116,7 @@ module Lint =
         { IndentationRuleContext : Map<int,bool*int>
           NoTabCharactersRuleContext : (string * Range.range) list }
 
-    let runAstNodeRules (rules:RuleMetadata<AstNodeRuleConfig> []) typeCheckResults (filePath:string) (fileContent:string) syntaxArray skipArray =
+    let runAstNodeRules (rules:RuleMetadata<AstNodeRuleConfig> []) (globalConfig : Rules.GlobalRuleConfig) typeCheckResults (filePath:string) (fileContent:string) syntaxArray skipArray =
         let mutable indentationRuleState = Map.empty
         let mutable noTabCharactersRuleState = List.empty
 
@@ -135,7 +135,8 @@ module Lint =
                       GetParents = getParents
                       FilePath = filePath
                       FileContent = fileContent
-                      CheckInfo = typeCheckResults }
+                      CheckInfo = typeCheckResults
+                      GlobalConfig = globalConfig }
                 // Build state for rules with context.
                 indentationRuleState <- Indentation.ContextBuilder.builder indentationRuleState astNode.Actual
                 noTabCharactersRuleState <- NoTabCharacters.ContextBuilder.builder noTabCharactersRuleState astNode.Actual
@@ -150,7 +151,7 @@ module Lint =
         rules |> Array.iter (fun rule -> rule.RuleConfig.Cleanup())
         (astNodeSuggestions, context)
 
-    let runLineRules (lineRules:Configuration.LineRules) (filePath:string) (fileContent:string) (context:Context) =
+    let runLineRules (lineRules:Configuration.LineRules) (globalConfig : Rules.GlobalRuleConfig) (filePath:string) (fileContent:string) (context:Context) =
         fileContent
         |> String.toLines
         |> Array.collect (fun (line, lineNumber, isLastLine) ->
@@ -159,7 +160,8 @@ module Lint =
                   LineNumber = lineNumber + 1
                   IsLastLine = isLastLine
                   FilePath = filePath
-                  FileContent = fileContent }
+                  FileContent = fileContent
+                  GlobalConfig =  globalConfig }
 
             let indentationError =
                 lineRules.IndentationRule
@@ -225,8 +227,8 @@ module Lint =
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray fileInfo.Ast
 
             // Collect suggestions for AstNode rules
-            let (astNodeSuggestions, context) = runAstNodeRules enabledRules.AstNodeRules fileInfo.TypeCheckResults fileInfo.File fileInfo.Text syntaxArray skipArray
-            let lineSuggestions = runLineRules enabledRules.LineRules fileInfo.File fileInfo.Text context
+            let (astNodeSuggestions, context) = runAstNodeRules enabledRules.AstNodeRules enabledRules.GlobalConfig fileInfo.TypeCheckResults fileInfo.File fileInfo.Text syntaxArray skipArray
+            let lineSuggestions = runLineRules enabledRules.LineRules enabledRules.GlobalConfig fileInfo.File fileInfo.Text context
 
             [|
                 lineSuggestions

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -118,10 +118,10 @@ module Lint =
           NoTabCharactersRuleContext : (string * Range.range) list }
 
     /// Runs all rules which take a node of the AST as input.
-    val runAstNodeRules : RuleMetadata<AstNodeRuleConfig> [] -> FSharpCheckFileResults option -> string -> string -> AbstractSyntaxArray.Node [] -> AbstractSyntaxArray.Skip [] -> Suggestion.LintWarning [] * Context
+    val runAstNodeRules : RuleMetadata<AstNodeRuleConfig> [] -> Rules.GlobalRuleConfig -> FSharpCheckFileResults option -> string -> string -> AbstractSyntaxArray.Node [] -> AbstractSyntaxArray.Skip [] -> Suggestion.LintWarning [] * Context
 
     /// Runs all rules which take a line of text as input.
-    val runLineRules : LineRules -> string -> string -> Context -> Suggestion.LintWarning []
+    val runLineRules : LineRules -> Rules.GlobalRuleConfig -> string -> string -> Context -> Suggestion.LintWarning []
 
     /// Lints an entire F# solution by linting all projects specified in the `.sln` file.
     val lintSolution : optionalParams:OptionalLintParameters -> solutionFilePath:string -> LintResult

--- a/src/FSharpLint.Core/DefaultConfiguration.json
+++ b/src/FSharpLint.Core/DefaultConfiguration.json
@@ -2,6 +2,9 @@
     "IgnoreFiles": [
         "assemblyinfo.*"
     ],
+    "global": {
+        "numIndentationSpaces": 4
+    },
     "TypedItemSpacing": {
         "enabled": false,
         "config": {
@@ -285,8 +288,10 @@
             "compare x y >  0 ===> x >  y",
             "compare x y =  0 ===> x =  y",
             "compare x y <> 0 ===> x <> y",
+
             "List.head (List.sort x) ===> List.min x",
             "List.head (List.sortBy f x) ===> List.minBy f x",
+
             "List.map f (List.map g x) ===> List.map (g >> f) x",
             "Array.map f (Array.map g x) ===> Array.map (g >> f) x",
             "Seq.map f (Seq.map g x) ===> Seq.map (g >> f) x",
@@ -309,18 +314,22 @@
             "(List.length x) > 0 ===> not (List.isEmpty x)",
             "(Array.length x) <> 0 ===> not (Array.isEmpty x)",
             "(Seq.length x) <> 0 ===> not (Seq.isEmpty x)",
+
             "List.concat (List.map f x) ===> List.collect f x",
             "Array.concat (Array.map f x) ===> Array.collect f x",
             "Seq.concat (Seq.map f x) ===> Seq.collect f x",
+
             "List.isEmpty (List.filter f x) ===> not (List.exists f x)",
             "Array.isEmpty (Array.filter f x) ===> not (Array.exists f x)",
             "Seq.isEmpty (Seq.filter f x) ===> not (Seq.exists f x)",
             "not (List.isEmpty (List.filter f x)) ===> List.exists f x",
             "not (Array.isEmpty (Array.filter f x)) ===> Array.exists f x",
             "not (Seq.isEmpty (Seq.filter f x)) ===> Seq.exists f x",
+
             "List.length x >= 0 ===> true",
             "Array.length x >= 0 ===> true",
             "Seq.length x >= 0 ===> true",
+
             "x = true ===> x",
             "x = false ===> not x",
             "true = a ===> a",
@@ -332,7 +341,9 @@
             "if a then true else false ===> a",
             "if a then false else true ===> not a",
             "not (not x) ===> x",
+
             "(fst x, snd x) ===> x",
+
             "true && x ===> x",
             "false && x ===> false",
             "true || x ===> true",
@@ -348,6 +359,7 @@
             "x - 0 ===> x",
             "x * 1 ===> x",
             "x / 1 ===> x",
+
             "List.fold (+) 0 x ===> List.sum x",
             "Array.fold (+) 0 x ===> Array.sum x",
             "Seq.fold (+) 0 x ===> Seq.sum x",
@@ -360,22 +372,29 @@
             "(List.take x y, List.skip x y) ===> List.splitAt x y",
             "(Array.take x y, Array.skip x y) ===> Array.splitAt x y",
             "(Seq.take x y, Seq.skip x y) ===> Seq.splitAt x y",
+
             "List.empty ===> []",
             "Array.empty ===> [||]",
+
             "x::[] ===> [x]",
             "pattern: x::[] ===> [x]",
+
             "x @ [] ===> x",
+
             "List.isEmpty [] ===> true",
             "Array.isEmpty [||] ===> true",
+
             "fun _ -> () ===> ignore",
             "fun x -> x ===> id",
             "id x ===> x",
             "id >> f ===> f",
             "f >> id ===> f",
+
             "x = null ===> isNull x",
             "null = x ===> isNull x",
             "x <> null ===> not (isNull x)",
             "null <> x ===> not (isNull x)",
+
             "Array.append a (Array.append b c) ===> Array.concat [|a; b; c|]"
         ]
     }

--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -7,6 +7,16 @@ open FSharpLint.Framework.AbstractSyntaxArray
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Suggestion
 
+type GlobalRuleConfig =
+    {
+        numIndentationSpaces : int
+    }
+with
+    static member Default =
+        {
+            GlobalRuleConfig.numIndentationSpaces = 4
+        }
+
 type AstNodeRuleParams =
     { AstNode : AstNode
       NodeHashcode : int
@@ -16,14 +26,16 @@ type AstNodeRuleParams =
       GetParents : int -> AstNode list
       FilePath : string
       FileContent : string
-      CheckInfo : FSharpCheckFileResults option }
+      CheckInfo : FSharpCheckFileResults option
+      GlobalConfig : GlobalRuleConfig }
 
 type LineRuleParams =
     { Line : string
       LineNumber : int
       IsLastLine : bool
       FilePath : string
-      FileContent : string }
+      FileContent : string
+      GlobalConfig : GlobalRuleConfig }
 
 type RuleMetadata<'config> =
   { Name : string

--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -7,6 +7,8 @@ open FSharpLint.Framework.AbstractSyntaxArray
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Suggestion
 
+// Non-standard record field names for serialization
+// fsharplint:disable RecordFieldNames
 type GlobalRuleConfig =
     {
         numIndentationSpaces : int
@@ -16,6 +18,7 @@ with
         {
             GlobalRuleConfig.numIndentationSpaces = 4
         }
+// fsharplint:enable RecordFieldNames
 
 type AstNodeRuleParams =
     { AstNode : AstNode

--- a/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
@@ -17,7 +17,7 @@ let check (args:AstNodeRuleParams) matchExprRange (clauses:SynMatchClause list) 
         |> Option.bind (fun firstClause ->
             let clauseIndentation = ExpressionUtilities.getLeadingSpaces firstClause.Range args.FileContent
             if isLambda then
-                if clauseIndentation <> matchStartIndentation + args.globalConfig.numIndentationSpaces then
+                if clauseIndentation <> matchStartIndentation + args.GlobalConfig.numIndentationSpaces then
                     { Range = firstClause.Range
                       Message = Resources.GetString("RulesFormattingLambdaPatternMatchClauseIndentationError")
                       SuggestedFix = None

--- a/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
@@ -17,7 +17,7 @@ let check (args:AstNodeRuleParams) matchExprRange (clauses:SynMatchClause list) 
         |> Option.bind (fun firstClause ->
             let clauseIndentation = ExpressionUtilities.getLeadingSpaces firstClause.Range args.FileContent
             if isLambda then
-                if clauseIndentation <> matchStartIndentation + 4 then
+                if clauseIndentation <> matchStartIndentation + args.globalConfig.numIndentationSpaces then
                     { Range = firstClause.Range
                       Message = Resources.GetString("RulesFormattingLambdaPatternMatchClauseIndentationError")
                       SuggestedFix = None

--- a/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
@@ -19,7 +19,7 @@ let check (args:AstNodeRuleParams) _ (clauses:SynMatchClause list) _ =
             guard
             |> Option.map (fun expr -> expr.Range.EndLine)
             |> Option.defaultValue pat.Range.EndLine
-        if expr.Range.StartLine <> matchPatternEndLine && exprIndentation <> clauseIndentation + 4 then
+        if expr.Range.StartLine <> matchPatternEndLine && exprIndentation <> clauseIndentation + args.globalConfig.numIndentationSpaces then
             { Range = expr.Range
               Message = Resources.GetString("RulesFormattingMatchExpressionIndentationError")
               SuggestedFix = None

--- a/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
@@ -19,7 +19,7 @@ let check (args:AstNodeRuleParams) _ (clauses:SynMatchClause list) _ =
             guard
             |> Option.map (fun expr -> expr.Range.EndLine)
             |> Option.defaultValue pat.Range.EndLine
-        if expr.Range.StartLine <> matchPatternEndLine && exprIndentation <> clauseIndentation + args.globalConfig.numIndentationSpaces then
+        if expr.Range.StartLine <> matchPatternEndLine && exprIndentation <> clauseIndentation + args.GlobalConfig.numIndentationSpaces then
             { Range = expr.Range
               Message = Resources.GetString("RulesFormattingMatchExpressionIndentationError")
               SuggestedFix = None

--- a/src/FSharpLint.Core/Rules/Formatting/UnionDefinitionIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/UnionDefinitionIndentation.fs
@@ -2,14 +2,12 @@ module FSharpLint.Rules.UnionDefinitionIndentation
 
 open System
 open FSharp.Compiler.Ast
-open FSharp.Compiler.Range
 open FSharpLint.Framework
 open FSharpLint.Framework.Suggestion
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
-open FSharpLint.Framework.ExpressionUtilities
 
-let getUnionCaseStartColumn (SynUnionCase.UnionCase (attrs, name, _, _, _, range)) =
+let getUnionCaseStartColumn (SynUnionCase.UnionCase (attrs, _, _, _, _, range)) =
     match attrs |> List.tryHead with
     | Some attr ->
         // startcolumn of the attributes now includes the `[<` starter sigil, so we can just use it!
@@ -25,7 +23,7 @@ let checkUnionDefinitionIndentation (args:AstNodeRuleParams) typeDefnRepr typeDe
         | [_] -> Array.empty
         | firstCase :: _ ->
             let indentationLevelError =
-                if getUnionCaseStartColumn firstCase <> typeDefnStartColumn + 1 then
+                if getUnionCaseStartColumn firstCase - 2 <> typeDefnStartColumn + args.globalConfig.numIndentationSpaces then
                     { Range = firstCase.Range
                       Message = Resources.GetString("RulesFormattingUnionDefinitionIndentationError")
                       SuggestedFix = None
@@ -55,8 +53,11 @@ let checkUnionDefinitionIndentation (args:AstNodeRuleParams) typeDefnRepr typeDe
 
 let runner args =
     match args.AstNode with
-    | AstNode.TypeDefinition (SynTypeDefn.TypeDefn (_, repr, members, defnRange)) ->
-        checkUnionDefinitionIndentation args repr defnRange.StartColumn
+    | AstNode.ModuleDeclaration (SynModuleDecl.Types (typeDefns, typesRange)) ->
+        typeDefns
+        |> List.toArray
+        |> Array.collect (fun (SynTypeDefn.TypeDefn (_, repr, _, _)) ->
+            checkUnionDefinitionIndentation args repr typesRange.StartColumn)
     | _ ->
         Array.empty
 

--- a/src/FSharpLint.Core/Rules/Formatting/UnionDefinitionIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/UnionDefinitionIndentation.fs
@@ -23,7 +23,7 @@ let checkUnionDefinitionIndentation (args:AstNodeRuleParams) typeDefnRepr typeDe
         | [_] -> Array.empty
         | firstCase :: _ ->
             let indentationLevelError =
-                if getUnionCaseStartColumn firstCase - 2 <> typeDefnStartColumn + args.globalConfig.numIndentationSpaces then
+                if getUnionCaseStartColumn firstCase - 2 <> typeDefnStartColumn + args.GlobalConfig.numIndentationSpaces then
                     { Range = firstCase.Range
                       Message = Resources.GetString("RulesFormattingUnionDefinitionIndentationError")
                       SuggestedFix = None

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -79,14 +79,6 @@ module ContextBuilder =
         |> List.fold (fun current (line, indentationOverride) ->
             Map.add line indentationOverride current) current
 
-[<RequireQualifiedAccess>]
-type Config =
-    {
-        // fsharplint:disable RecordFieldNames
-        numberOfIndentationSpaces : int
-        // fsharplint:enable RecordFieldNames
-    }
-
 let checkIndentation (expectedSpaces:int) (line:string) (lineNumber:int) (indentationOverrides:Map<int,bool*int>) =
     let numLeadingSpaces = line.Length - line.TrimStart().Length
     let range = mkRange "" (mkPos lineNumber 0) (mkPos lineNumber numLeadingSpaces)
@@ -120,12 +112,12 @@ let checkIndentation (expectedSpaces:int) (line:string) (lineNumber:int) (indent
     else
         None
 
-let runner (config:Config) context args =
-    checkIndentation config.numberOfIndentationSpaces args.Line args.LineNumber context
+let runner context args =
+    checkIndentation args.globalConfig.numIndentationSpaces args.line args.lineNumber context
     |> Option.toArray
 
-let rule config =
-    { Name = "Indentation"
-      Identifier = Identifiers.Indentation
-      RuleConfig = { Runner = runner config } }
+let rule =
+    { name = "Indentation"
+      identifier = Identifiers.Indentation
+      ruleConfig = { runner = runner } }
     |> IndentationRule

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -113,11 +113,11 @@ let checkIndentation (expectedSpaces:int) (line:string) (lineNumber:int) (indent
         None
 
 let runner context args =
-    checkIndentation args.globalConfig.numIndentationSpaces args.line args.lineNumber context
+    checkIndentation args.GlobalConfig.numIndentationSpaces args.Line args.LineNumber context
     |> Option.toArray
 
 let rule =
-    { name = "Indentation"
-      identifier = Identifiers.Indentation
-      ruleConfig = { runner = runner } }
+    { Name = "Indentation"
+      Identifier = Identifiers.Indentation
+      RuleConfig = { Runner = runner } }
     |> IndentationRule

--- a/tests/FSharpLint.Core.Tests/Framework/TestConfiguration.fs
+++ b/tests/FSharpLint.Core.Tests/Framework/TestConfiguration.fs
@@ -125,8 +125,8 @@ type TestConfiguration() =
         let config = {
             Configuration.Zero with
                 typography =
-                    Some { TypographyConfig.indentation = Some { RuleConfig.enabled = true; config = Some { Indentation.Config.numberOfIndentationSpaces = 4 } }
-                           maxCharactersOnLine = None
+                    Some { TypographyConfig.maxCharactersOnLine = Some { RuleConfig.enabled = true; config = Some { MaxCharactersOnLine.Config.maxCharactersOnLine = 4 } }
+                           indentation = None
                            trailingWhitespaceOnLine = None
                            maxLinesInFile = None
                            trailingNewLineInFile = None
@@ -139,10 +139,10 @@ type TestConfiguration() =
         let expectedJson =
             """{
     "typography": {
-        "indentation": {
+        "maxCharactersOnLine": {
             "enabled": true,
             "config": {
-                "numberOfIndentationSpaces": 4
+                "maxCharactersOnLine": 4
             }
         }
     }

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/UnionDefinitionIndentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/UnionDefinitionIndentation.fs
@@ -54,6 +54,21 @@ type T =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for correctly indented union definition cases in multi-type declaration``() =
+        this.Parse"""
+module Program
+
+type T =
+    | T1 of int
+    | T2 of int
+and V =
+    | V1 of int
+    | V2 of int
+"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for correctly indented union definition cases with attribute``() =
         this.Parse"""
 module Program

--- a/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
@@ -35,7 +35,7 @@ type TestAstNodeRuleBase (rule:Rule) =
                 | Some false -> None
                 | _ -> parseInfo.TypeCheckResults
             let suggestions = runAstNodeRules (Array.singleton rule) globalConfig checkResult (Option.defaultValue "" fileName) input syntaxArray skipArray |> fst
-            rule.ruleConfig.cleanup()
+            rule.RuleConfig.Cleanup()
 
             suggestions |> Array.iter this.PostSuggestion
         | _ ->

--- a/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
@@ -58,6 +58,6 @@ type TestHintMatcherBase () =
                 | Some false -> None
                 | _ -> parseInfo.TypeCheckResults
             let suggestions = runAstNodeRules (Array.singleton rule) globalConfig checkResult (Option.defaultValue "" fileName) input syntaxArray skipArray |> fst
-            suggestions |> Array.iter this.postSuggestion
+            suggestions |> Array.iter this.PostSuggestion
         | _ ->
             failwithf "Failed to parse"

--- a/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
@@ -9,6 +9,7 @@ open FSharpLint.Framework.HintParser.MergeSyntaxTrees
 open FSharpLint.Framework.ParseFile
 open FSharpLint.Rules
 
+open FSharpLint.Framework.Rules
 open FSharpLint.Rules.HintMatcher
 
 let private generateHintConfig hints =
@@ -32,7 +33,7 @@ type TestHintMatcherBase () =
     member this.SetConfig (hints:string list) =
         hintTrie <- generateHintConfig hints
 
-    override this.Parse (input:string, ?fileName:string, ?checkFile:bool) =
+    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig:GlobalRuleConfig) =
         let checker = FSharpChecker.Create()
 
         let parseResults =
@@ -47,6 +48,8 @@ type TestHintMatcherBase () =
             | Rules.AstNodeRule rule -> rule
             | _ -> failwithf "TestHintMatcherBase only accepts AstNodeRules"
 
+        let globalConfig = globalConfig |> Option.defaultValue GlobalRuleConfig.Default
+
         match parseResults with
         | ParseFileResult.Success parseInfo ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray parseInfo.Ast
@@ -54,7 +57,7 @@ type TestHintMatcherBase () =
                 match checkFile with
                 | Some false -> None
                 | _ -> parseInfo.TypeCheckResults
-            let suggestions = runAstNodeRules (Array.singleton rule) checkResult (Option.defaultValue "" fileName) input syntaxArray skipArray |> fst
-            suggestions |> Array.iter this.PostSuggestion
+            let suggestions = runAstNodeRules (Array.singleton rule) globalConfig checkResult (Option.defaultValue "" fileName) input syntaxArray skipArray |> fst
+            suggestions |> Array.iter this.postSuggestion
         | _ ->
             failwithf "Failed to parse"

--- a/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
@@ -11,7 +11,7 @@ open FSharpLint.Framework.Rules
 type TestIndentationRuleBase (rule:Rule) =
     inherit TestRuleBase.TestRuleBase()
 
-    override this.Parse (input:string, ?fileName:string, ?checkFile:bool) =
+    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig:GlobalRuleConfig) =
         let checker = FSharpChecker.Create()
         let sourceText = SourceText.ofString input
 
@@ -26,13 +26,14 @@ type TestIndentationRuleBase (rule:Rule) =
             | IndentationRule rule -> rule
             | _ -> failwithf "TestIndentationRuleBase only accepts IndentationRules"
 
+        let globalConfig = globalConfig |> Option.defaultValue GlobalRuleConfig.Default
 
         match parseResults.ParseTree with
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
-            let (_, context) = runAstNodeRules Array.empty None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = Some rule; NoTabCharactersRule = None; GenericLineRules = [||] }
+            let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
+            let lineRules = { LineRules.IndentationRule = Some rule; noTabCharactersRule = None; genericLineRules = [||] }
 
-            runLineRules lineRules fileName input context
+            runLineRules lineRules globalConfig fileName input context
             |> Array.iter this.PostSuggestion
         | None -> ()

--- a/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
@@ -32,7 +32,7 @@ type TestIndentationRuleBase (rule:Rule) =
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
             let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = Some rule; noTabCharactersRule = None; genericLineRules = [||] }
+            let lineRules = { LineRules.IndentationRule = Some rule; NoTabCharactersRule = None; GenericLineRules = [||] }
 
             runLineRules lineRules globalConfig fileName input context
             |> Array.iter this.PostSuggestion

--- a/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
@@ -11,7 +11,7 @@ open FSharpLint.Framework.Rules
 type TestLineRuleBase (rule:Rule) =
     inherit TestRuleBase.TestRuleBase()
 
-    override this.Parse (input:string, ?fileName:string, ?checkFile:bool) =
+    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig : GlobalRuleConfig) =
         let checker = FSharpChecker.Create()
         let sourceText = SourceText.ofString input
 
@@ -20,6 +20,8 @@ type TestLineRuleBase (rule:Rule) =
         let projectOptions, _ = checker.GetProjectOptionsFromScript(fileName, sourceText) |> Async.RunSynchronously
         let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
         let parseResults = checker.ParseFile("test.fsx", sourceText, parsingOptions) |> Async.RunSynchronously
+
+        let globalConfig = globalConfig |> Option.defaultValue GlobalRuleConfig.Default
 
         let rule =
             match rule with
@@ -30,9 +32,9 @@ type TestLineRuleBase (rule:Rule) =
         match parseResults.ParseTree with
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
-            let (_, context) = runAstNodeRules Array.empty None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = None; NoTabCharactersRule = None; GenericLineRules = [|rule|] }
+            let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
+            let lineRules = { LineRules.IndentationRule = None; noTabCharactersRule = None; genericLineRules = [|rule|] }
 
-            runLineRules lineRules fileName input context
-            |> Array.iter this.PostSuggestion
+            runLineRules lineRules globalConfig fileName input context
+            |> Array.iter this.postSuggestion
         | None -> ()

--- a/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
@@ -11,7 +11,7 @@ open FSharpLint.Framework.Rules
 type TestLineRuleBase (rule:Rule) =
     inherit TestRuleBase.TestRuleBase()
 
-    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig : GlobalRuleConfig) =
+    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig:GlobalRuleConfig) =
         let checker = FSharpChecker.Create()
         let sourceText = SourceText.ofString input
 
@@ -33,8 +33,8 @@ type TestLineRuleBase (rule:Rule) =
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
             let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = None; noTabCharactersRule = None; genericLineRules = [|rule|] }
+            let lineRules = { LineRules.IndentationRule = None; NoTabCharactersRule = None; GenericLineRules = [|rule|] }
 
             runLineRules lineRules globalConfig fileName input context
-            |> Array.iter this.postSuggestion
+            |> Array.iter this.PostSuggestion
         | None -> ()

--- a/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
@@ -32,7 +32,7 @@ type TestNoTabCharactersRuleBase (rule:Rule) =
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
             let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = None; noTabCharactersRule = Some rule; genericLineRules = [||] }
+            let lineRules = { LineRules.IndentationRule = None; NoTabCharactersRule = Some rule; GenericLineRules = [||] }
 
             runLineRules lineRules globalConfig fileName input context
             |> Array.iter this.PostSuggestion

--- a/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
@@ -11,7 +11,7 @@ open FSharpLint.Framework.Rules
 type TestNoTabCharactersRuleBase (rule:Rule) =
     inherit TestRuleBase.TestRuleBase()
 
-    override this.Parse (input:string, ?fileName:string, ?checkFile:bool) =
+    override this.Parse (input:string, ?fileName:string, ?checkFile:bool, ?globalConfig:GlobalRuleConfig) =
         let checker = FSharpChecker.Create()
         let sourceText = SourceText.ofString input
 
@@ -26,13 +26,14 @@ type TestNoTabCharactersRuleBase (rule:Rule) =
             | NoTabCharactersRule rule -> rule
             | _ -> failwithf "TestNoTabCharactersRuleBase only accepts NoTabCharactersRules"
 
+        let globalConfig = globalConfig |> Option.defaultValue GlobalRuleConfig.Default
 
         match parseResults.ParseTree with
         | Some tree ->
             let (syntaxArray, skipArray) = AbstractSyntaxArray.astToArray tree
-            let (_, context) = runAstNodeRules Array.empty None fileName input syntaxArray skipArray
-            let lineRules = { LineRules.IndentationRule = None; NoTabCharactersRule = Some rule; GenericLineRules = [||] }
+            let (_, context) = runAstNodeRules Array.empty globalConfig None fileName input syntaxArray skipArray
+            let lineRules = { LineRules.IndentationRule = None; noTabCharactersRule = Some rule; genericLineRules = [||] }
 
-            runLineRules lineRules fileName input context
+            runLineRules lineRules globalConfig fileName input context
             |> Array.iter this.PostSuggestion
         | None -> ()

--- a/tests/FSharpLint.Core.Tests/Rules/TestRuleBase.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestRuleBase.fs
@@ -4,13 +4,14 @@ open System
 open System.Text
 open NUnit.Framework
 open FSharpLint.Framework
+open FSharpLint.Framework.Rules
 open FSharpLint.Framework.Suggestion
 
 [<AbstractClass>]
 type TestRuleBase () =
     let suggestions = ResizeArray<_>()
 
-    abstract Parse : string * ?fileName:string * ?checkFile:bool -> unit
+    abstract Parse : string * ?fileName:string * ?checkFile:bool * ?globalConfig:GlobalRuleConfig -> unit
 
     member __.PostSuggestion (suggestion:Suggestion.LintWarning) =
         if not suggestion.Details.TypeChecks.IsEmpty then

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -5,7 +5,7 @@ open FSharpLint.Rules
 
 [<TestFixture>]
 type TestTypographyIndentation() =
-    inherit TestIndentationRuleBase.TestIndentationRuleBase(Indentation.rule { numberOfIndentationSpaces = 4 })
+    inherit TestIndentationRuleBase.TestIndentationRuleBase(Indentation.rule)
 
     [<Test>]
     member this.``Error for incorrect indentation``() =


### PR DESCRIPTION
Adds `globals` section to configuration to allow sharing settings between rules to maintain consistency. The only available global setting now is `numIndentationSpaces`, and it is used by all rules which depend on knowing what the expected number of spaces per level of indentation is. This avoids having to define this setting multiple times for each rule that depends on it.

Also fixes a bug in the `UnionDefinitionIndentation` rule. It was not correctly handling type definitions for multiple types (using the `and` keyword).