### PR TITLE
remove local rule settings parameter

### DIFF
--- a/src/FSharpLint.Core/DefaultConfiguration.json
+++ b/src/FSharpLint.Core/DefaultConfiguration.json
@@ -243,10 +243,7 @@
     "UselessBinding": { "enabled": true },
     "TupleOfWildcards": { "enabled": true },
     "Indentation": {
-        "enabled": false,
-        "config": {
-            "numberOfIndentationSpaces": 4
-        }
+        "enabled": false
     },
     "MaxCharactersOnLine": {
         "enabled": false,


### PR DESCRIPTION
Global settings is used for `numIndentationSpaces` according to [docu](http://fsprojects.github.io/FSharpLint/rules/FL0059.html) and `FSharpLint.Framework.Configuration`:

```fsharp
type TypographyConfig =
    { indentation : EnabledConfig option
```