### PR TITLE
Handle exceptional cases for indentation rule

### DIFF
--- a/docs-gen/markdown/MSBuildTask.md
+++ b/docs-gen/markdown/MSBuildTask.md
@@ -7,7 +7,7 @@ To set this up, first [install the FSharpLint dotnet tool](DotnetTool).
 Then, you can add the following to any of your projects to run linting after build completion for that project:
 
     [lang=xml]
-    <Target Name="FSharpLint" AfterTargets="AfterBuild">
+    <Target Name="FSharpLint" AfterTargets="BeforeBuild">
      <Exec
        Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
        ConsoleToMsBuild="true"

--- a/docs/MSBuildTask.html
+++ b/docs/MSBuildTask.html
@@ -39,7 +39,7 @@
 <span class="l">6: </span>
 <span class="l">7: </span>
 </pre></td>
-<td class="snippet"><pre class="fssnip highlighted"><code lang="xml"><span class="k">&lt;</span><span class="i">Target</span> <span class="o">Name</span><span class="k">="FSharpLint"</span> <span class="o">AfterTargets</span><span class="k">="AfterBuild"</span><span class="k">&gt;</span>
+<td class="snippet"><pre class="fssnip highlighted"><code lang="xml"><span class="k">&lt;</span><span class="i">Target</span> <span class="o">Name</span><span class="k">="FSharpLint"</span> <span class="o">AfterTargets</span><span class="k">="BeforeBuild"</span><span class="k">&gt;</span>
  <span class="k">&lt;</span><span class="i">Exec</span>
    <span class="o">Command</span><span class="k">="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"</span>
    <span class="o">ConsoleToMsBuild</span><span class="k">="true"</span>

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -270,14 +270,14 @@ type NumberOfItemsConfig =
       maxNumberOfFunctionParameters : RuleConfig<Helper.NumberOfItems.Config> option
       maxNumberOfMembers : RuleConfig<Helper.NumberOfItems.Config> option
       maxNumberOfBooleanOperatorsInCondition : RuleConfig<Helper.NumberOfItems.Config> option }
- with
+with
     member this.Flatten() =
-         [|
+        [|
             this.maxNumberOfItemsInTuple |> Option.bind (constructRuleWithConfig MaxNumberOfItemsInTuple.rule) |> Option.toArray
             this.maxNumberOfFunctionParameters |> Option.bind (constructRuleWithConfig MaxNumberOfFunctionParameters.rule) |> Option.toArray
             this.maxNumberOfMembers |> Option.bind (constructRuleWithConfig MaxNumberOfMembers.rule) |> Option.toArray
             this.maxNumberOfBooleanOperatorsInCondition |> Option.bind (constructRuleWithConfig MaxNumberOfBooleanOperatorsInCondition.rule) |> Option.toArray
-         |] |> Array.concat
+        |] |> Array.concat
 
 type BindingConfig =
     { favourIgnoreOverLetWild : EnabledConfig option
@@ -286,12 +286,12 @@ type BindingConfig =
       tupleOfWildcards : EnabledConfig option }
  with
     member this.Flatten() =
-         [|
-            this.favourIgnoreOverLetWild |> Option.bind (constructRuleIfEnabled FavourIgnoreOverLetWild.rule) |> Option.toArray
-            this.wildcardNamedWithAsPattern |> Option.bind (constructRuleIfEnabled WildcardNamedWithAsPattern.rule) |> Option.toArray
-            this.uselessBinding |> Option.bind (constructRuleIfEnabled UselessBinding.rule) |> Option.toArray
-            this.tupleOfWildcards |> Option.bind (constructRuleIfEnabled TupleOfWildcards.rule) |> Option.toArray
-         |] |> Array.concat
+        [|
+           this.favourIgnoreOverLetWild |> Option.bind (constructRuleIfEnabled FavourIgnoreOverLetWild.rule) |> Option.toArray
+           this.wildcardNamedWithAsPattern |> Option.bind (constructRuleIfEnabled WildcardNamedWithAsPattern.rule) |> Option.toArray
+           this.uselessBinding |> Option.bind (constructRuleIfEnabled UselessBinding.rule) |> Option.toArray
+           this.tupleOfWildcards |> Option.bind (constructRuleIfEnabled TupleOfWildcards.rule) |> Option.toArray
+        |] |> Array.concat
 
 type ConventionsConfig =
     { recursiveAsyncFunction : EnabledConfig option

--- a/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
+++ b/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
@@ -301,14 +301,14 @@ module private MatchExpression =
     and private matchIf arguments =
         match (arguments.Expression, arguments.Hint) with
         | AstNode.Expression(SynExpr.IfThenElse(cond, expr, None, _, _, _, _)),
-          Expression.If(hintCond, hintExpr, None) ->
-            arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
-            (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr)
+            Expression.If(hintCond, hintExpr, None) ->
+                arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
+                (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr)
         | AstNode.Expression(SynExpr.IfThenElse(cond, expr, Some(elseExpr), _, _, _, _)),
-          Expression.If(hintCond, hintExpr, Some(Expression.Else(hintElseExpr))) ->
-            arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
-            (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr) &&~
-            (arguments.SubHint(Expression elseExpr, hintElseExpr) |> matchHintExpr)
+            Expression.If(hintCond, hintExpr, Some(Expression.Else(hintElseExpr))) ->
+                arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
+                (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr) &&~
+                (arguments.SubHint(Expression elseExpr, hintElseExpr) |> matchHintExpr)
         | _ -> NoMatch
 
     and matchLambda arguments =

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -47,6 +47,11 @@ module ContextBuilder =
 
     let private indentationOverridesForNode (node:AstNode) =
         match node with
+        | TypeDefinition (SynTypeDefn.TypeDefn(_, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Record(_, fields, _), _), _, _)) ->
+             fields
+             |> List.map (fun (SynField.Field (_, _, _, _, _, _, _, range)) -> range)
+             |> firstRangePerLine
+             |> createAbsoluteAndOffsetOverridesBasedOnFirst
         | Expression(SynExpr.Record(recordFields=recordFields)) ->
             recordFields
             |> List.map (fun ((fieldName, _), _, _) -> fieldName.Range)

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -52,17 +52,22 @@ module ContextBuilder =
              |> List.map (fun (SynField.Field (_, _, _, _, _, _, _, range)) -> range)
              |> firstRangePerLine
              |> createAbsoluteAndOffsetOverridesBasedOnFirst
-        | Expression(SynExpr.Record(recordFields=recordFields)) ->
+        | Expression (SynExpr.Tuple (_, exprs, _, _)) ->
+            exprs
+             |> List.map (fun expr -> expr.Range)
+             |> firstRangePerLine
+             |> createAbsoluteAndOffsetOverridesBasedOnFirst
+        | Expression (SynExpr.Record(recordFields=recordFields)) ->
             recordFields
             |> List.map (fun ((fieldName, _), _, _) -> fieldName.Range)
             |> firstRangePerLine
             |> createAbsoluteAndOffsetOverridesBasedOnFirst
-        | Expression(SynExpr.ArrayOrListOfSeqExpr(expr=(SynExpr.CompExpr(isArrayOrList=true; expr=expr)))) ->
+        | Expression (SynExpr.ArrayOrListOfSeqExpr(expr=(SynExpr.CompExpr(isArrayOrList=true; expr=expr)))) ->
             extractSeqExprItems expr
             |> List.map (fun expr -> expr.Range)
             |> firstRangePerLine
             |> createAbsoluteAndOffsetOverridesBasedOnFirst
-        | Expression(SynExpr.ArrayOrList(exprs=exprs)) ->
+        | Expression (SynExpr.ArrayOrList(exprs=exprs)) ->
             exprs
             |> List.map (fun expr -> expr.Range)
             |> firstRangePerLine

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -73,7 +73,8 @@ module ContextBuilder =
             |> firstRangePerLine
             |> createAbsoluteAndOffsetOverridesBasedOnFirst
         | Expression(SynExpr.App(funcExpr=(SynExpr.App(funcExpr=SynExpr.Ident(ident); argExpr=innerArg)); argExpr=outerArg))
-            when ident.idText = "op_PipeRight" ->
+            when ident.idText = "op_PipeRight"
+            && outerArg.Range.EndLine <> innerArg.Range.StartLine ->
             let expectedIndentation = innerArg.Range.StartColumn
             createAbsoluteAndOffsetOverrides expectedIndentation outerArg.Range
         | Expression(SynExpr.ObjExpr(bindings=bindings; newExprRange=newExprRange)) ->

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -72,9 +72,8 @@ module ContextBuilder =
             |> List.map (fun expr -> expr.Range)
             |> firstRangePerLine
             |> createAbsoluteAndOffsetOverridesBasedOnFirst
-        | Expression(SynExpr.App(funcExpr=(SynExpr.App(funcExpr=SynExpr.Ident(ident); argExpr=innerArg)); argExpr=outerArg))
-            when ident.idText = "op_PipeRight"
-            && outerArg.Range.EndLine <> innerArg.Range.StartLine ->
+        | Expression(SynExpr.App(funcExpr=(SynExpr.App(isInfix=isInfix; argExpr=innerArg)); argExpr=outerArg))
+            when isInfix && outerArg.Range.EndLine <> innerArg.Range.StartLine ->
             let expectedIndentation = innerArg.Range.StartColumn
             createAbsoluteAndOffsetOverrides expectedIndentation outerArg.Range
         | Expression(SynExpr.ObjExpr(bindings=bindings; newExprRange=newExprRange)) ->

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -96,6 +96,19 @@ let pascalsTriangle =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for multi-line tuple``() =
+        this.Parse """
+module P
+
+let pascalsTriangle =
+    (1,
+     2,
+     3)"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+
+    [<Test>]
     member this.``No error for correct list member indentation``() =
         this.Parse """
 module P

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -133,6 +133,15 @@ let res = 1
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for pipeline on same line``() =
+        this.Parse """
+module P
+
+let res = 1 |> add 2"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for standard pipeline indentation``() =
         this.Parse """
 module P

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -133,6 +133,27 @@ let res = 1
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for exceptional composition indentation``() =
+        this.Parse """
+module P
+
+let res = add 2
+          >> sub 3"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional infix indentation``() =
+        this.Parse """
+module P
+
+let res = 1
+          + 2
+          + 3"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for pipeline on same line``() =
         this.Parse """
 module P

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -50,6 +50,15 @@ let rainbow =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for correct record field indentation in type definition``() =
+        this.Parse """
+type T =
+    { X : int
+      Y : string }"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for correct record field indentation with multiple fields per line``() =
         this.Parse """
 module P


### PR DESCRIPTION
Updates the indentation rule to handle some exceptional indentation cases:

- record fields should be aligned
- multi-line tuples
- infix operators across multiple lines