### PR TITLE
Add lint dotnet tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-fsharplint": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "paket"
       ]
+    },
+    "dotnet-fsharplint": {
+      "version": "0.14.0",
+      "commands": [
+        "dotnet-fsharplint"
+      ]
     }
   }
 }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,8 @@
   <Target Name="FSharpLint"
           AfterTargets="BeforeBuild"
           Condition="$(MSBuildProjectName) != 'FSharpLint.FunctionalTest.TestedProject'
-                    And $(MSBuildProjectName) != 'FSharpLint.Console'">
+                    And $(MSBuildProjectName) != 'FSharpLint.Console'
+                    And $(MSBuildProjectName) != 'FSharpLint.Console.Tests'">
    <Exec
      Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
      ConsoleToMsBuild="true"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,11 +1,11 @@
 <Project ToolsVersion="15.0">
   <Target Name="FSharpLint"
-          AfterTargets="AfterBuild"
+          AfterTargets="BeforeBuild"
           Condition="$(MSBuildProjectName) != 'FSharpLint.FunctionalTest.TestedProject'
                     And $(MSBuildProjectName) != 'FSharpLint.Console'">
    <Exec
      Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
      ConsoleToMsBuild="true"
-     IgnoreExitCode="true" />
+     IgnoreExitCode="false" />
   </Target>
 </Project>

--- a/docs-gen/markdown/MSBuildTask.md
+++ b/docs-gen/markdown/MSBuildTask.md
@@ -11,7 +11,7 @@ Then, you can add the following to any of your projects to run linting after bui
      <Exec
        Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
        ConsoleToMsBuild="true"
-       IgnoreExitCode="true"
+       IgnoreExitCode="false"
      />
     </Target>
 

--- a/docs/MSBuildTask.html
+++ b/docs/MSBuildTask.html
@@ -43,7 +43,7 @@
  <span class="k">&lt;</span><span class="i">Exec</span>
    <span class="o">Command</span><span class="k">="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"</span>
    <span class="o">ConsoleToMsBuild</span><span class="k">="true"</span>
-   <span class="o">IgnoreExitCode</span><span class="k">="true"</span>
+   <span class="o">IgnoreExitCode</span><span class="k">="false"</span>
  <span class="k">/&gt;</span>
 <span class="k">&lt;/</span><span class="i">Target</span><span class="k">&gt;</span>
 </code></pre></td></tr></table>

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -284,13 +284,13 @@ type BindingConfig =
       wildcardNamedWithAsPattern : EnabledConfig option
       uselessBinding : EnabledConfig option
       tupleOfWildcards : EnabledConfig option }
- with
+with
     member this.Flatten() =
         [|
-           this.favourIgnoreOverLetWild |> Option.bind (constructRuleIfEnabled FavourIgnoreOverLetWild.rule) |> Option.toArray
-           this.wildcardNamedWithAsPattern |> Option.bind (constructRuleIfEnabled WildcardNamedWithAsPattern.rule) |> Option.toArray
-           this.uselessBinding |> Option.bind (constructRuleIfEnabled UselessBinding.rule) |> Option.toArray
-           this.tupleOfWildcards |> Option.bind (constructRuleIfEnabled TupleOfWildcards.rule) |> Option.toArray
+            this.favourIgnoreOverLetWild |> Option.bind (constructRuleIfEnabled FavourIgnoreOverLetWild.rule) |> Option.toArray
+            this.wildcardNamedWithAsPattern |> Option.bind (constructRuleIfEnabled WildcardNamedWithAsPattern.rule) |> Option.toArray
+            this.uselessBinding |> Option.bind (constructRuleIfEnabled UselessBinding.rule) |> Option.toArray
+            this.tupleOfWildcards |> Option.bind (constructRuleIfEnabled TupleOfWildcards.rule) |> Option.toArray
         |] |> Array.concat
 
 type ConventionsConfig =
@@ -328,14 +328,14 @@ type TypographyConfig =
       noTabCharacters : EnabledConfig option }
 with
     member this.Flatten() =
-         [|
+        [|
             this.indentation |> Option.bind (constructRuleIfEnabled Indentation.rule) |> Option.toArray
             this.maxCharactersOnLine |> Option.bind (constructRuleWithConfig MaxCharactersOnLine.rule) |> Option.toArray
             this.trailingWhitespaceOnLine |> Option.bind (constructRuleWithConfig TrailingWhitespaceOnLine.rule) |> Option.toArray
             this.maxLinesInFile |> Option.bind (constructRuleWithConfig MaxLinesInFile.rule) |> Option.toArray
             this.trailingNewLineInFile |> Option.bind (constructRuleIfEnabled TrailingNewLineInFile.rule) |> Option.toArray
             this.noTabCharacters |> Option.bind (constructRuleIfEnabled NoTabCharacters.rule) |> Option.toArray
-         |] |> Array.concat
+        |] |> Array.concat
 
 let private getOrEmptyList hints = hints |> Option.defaultValue [||]
 
@@ -517,7 +517,7 @@ let loadConfig (configPath:string) =
 let defaultConfiguration =
     let assembly = typeof<Rules.Rule>.GetTypeInfo().Assembly
     let resourceName = Assembly.GetExecutingAssembly().GetManifestResourceNames()
-                     |> Seq.find (fun n -> n.EndsWith("DefaultConfiguration.json", System.StringComparison.Ordinal))
+                       |> Seq.find (fun n -> n.EndsWith("DefaultConfiguration.json", System.StringComparison.Ordinal))
     use stream = assembly.GetManifestResourceStream(resourceName)
     match stream with
     | null -> failwithf "Resource '%s' not found in assembly '%s'" resourceName (assembly.FullName)
@@ -654,6 +654,6 @@ let flattenConfig (config:Configuration) =
       DeprecatedRules = deprecatedAllRules
       AstNodeRules = astNodeRules.ToArray()
       LineRules =
-          { GenericLineRules = lineRules.ToArray()
-            IndentationRule = indentationRule
-            NoTabCharactersRule = noTabCharactersRule } }
+        { GenericLineRules = lineRules.ToArray()
+          IndentationRule = indentationRule
+          NoTabCharactersRule = noTabCharactersRule } }

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -28,7 +28,7 @@ module ConfigurationManagement =
 [<AutoOpen>]
 module Lint =
 
-    type BuildFailure = InvalidProjectFileMessage of string
+    type BuildFailure = | InvalidProjectFileMessage of string
 
     /// Reason for the linter failing.
     [<NoComparison>]
@@ -67,7 +67,7 @@ module Lint =
                 match this with
                 | ProjectFileCouldNotBeFound projectPath ->
                     String.Format(Resources.GetString("ConsoleProjectFileCouldNotBeFound"), projectPath)
-                | MSBuildFailedToLoadProjectFile (projectPath, InvalidProjectFileMessage(message)) ->
+                | MSBuildFailedToLoadProjectFile (projectPath, message) ->
                     String.Format(Resources.GetString("ConsoleMSBuildFailedToLoadProjectFile"), projectPath, message)
                 | FailedToLoadFile filepath ->
                     String.Format(Resources.GetString("ConsoleCouldNotFindFile"), filepath)
@@ -316,26 +316,28 @@ module Lint =
                     else
                         Path.Combine(projDir, f)
 
-                { ProjectFileName = projectFilePath
-                  SourceFiles = fa |> List.filter isSourceFile |> List.map compileFilesToAbsolutePath |> Array.ofList
-                  OtherOptions = fa |> List.filter (isSourceFile >> not) |> Array.ofList
-                  ReferencedProjects = [||]
-                  IsIncompleteTypeCheckEnvironment = false
-                  UseScriptResolutionRules = false
-                  LoadTime = DateTime.Now
-                  UnresolvedReferences = None
-                  OriginalLoadReferences = []
-                  ExtraProjectInfo = None
-                  ProjectId = None
-                  Stamp = None }
+                Ok {
+                      ProjectFileName = projectFilePath
+                      SourceFiles = fa |> List.filter isSourceFile |> List.map compileFilesToAbsolutePath |> Array.ofList
+                      OtherOptions = fa |> List.filter (isSourceFile >> not) |> Array.ofList
+                      ReferencedProjects = [||]
+                      IsIncompleteTypeCheckEnvironment = false
+                      UseScriptResolutionRules = false
+                      LoadTime = DateTime.Now
+                      UnresolvedReferences = None
+                      OriginalLoadReferences = []
+                      ExtraProjectInfo = None
+                      ProjectId = None
+                      Stamp = None
+                  }
             | Result.Ok _ ->
-                failwithf "error getting FSC args from msbuild info"
+                Error ( "error getting FSC args from msbuild info")
             | Result.Error error ->
-                failwithf "error getting FSC args from msbuild info, %A" error
+                Error (sprintf "error getting FSC args from msbuild info, %A" error)
         | Result.Ok r ->
-            failwithf "error getting msbuild info: more info returned than expected %A" r
+            Error (sprintf "error getting msbuild info: more info returned than expected %A" r)
         | Result.Error r ->
-            failwithf "error getting msbuild info: %A" r
+            Error (sprintf "error getting msbuild info: %A" r)
 
     let getFailedFiles = function
         | ParseFile.Failed failure -> Some failure
@@ -462,11 +464,15 @@ module Lint =
                     else
                         Failure (FailedToParseFilesInProject failedFiles)
 
-                let projectOptions = getProjectFileInfo optionalParams.ReleaseConfiguration projectFilePath
-                let compileFiles = projectOptions.SourceFiles |> Array.toList
-                match parseFilesInProject compileFiles projectOptions with
-                | Success _ -> lintWarnings |> Seq.toList |> LintResult.Success
-                | Failure x -> LintResult.Failure x
+                match getProjectFileInfo optionalParams.ReleaseConfiguration projectFilePath with
+                | Ok projectOptions ->
+                    let compileFiles = projectOptions.SourceFiles |> Array.toList
+                    match parseFilesInProject compileFiles projectOptions with
+                    | Success _ -> lintWarnings |> Seq.toList |> LintResult.Success
+                    | Failure x -> LintResult.Failure x
+                | Error error ->
+                    MSBuildFailedToLoadProjectFile (projectFilePath, BuildFailure.InvalidProjectFileMessage error)
+                    |> LintResult.Failure
             | Error err ->
                 RunTimeConfigError err
                 |> LintResult.Failure

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -252,7 +252,7 @@ module Lint =
                     |> Seq.map typeCheckSuggestion
                     |> Async.Parallel
                     |> runSynchronously
-                    |> Array.iter (function Some(suggestion) -> suggest suggestion | None -> ())
+                    |> Array.iter (function Some suggestion -> suggest suggestion | None -> ())
                 with
                 | :? TimeoutException -> () // Do nothing.
         with
@@ -316,22 +316,20 @@ module Lint =
                     else
                         Path.Combine(projDir, f)
 
-                Ok {
-                      ProjectFileName = projectFilePath
-                      SourceFiles = fa |> List.filter isSourceFile |> List.map compileFilesToAbsolutePath |> Array.ofList
-                      OtherOptions = fa |> List.filter (isSourceFile >> not) |> Array.ofList
-                      ReferencedProjects = [||]
-                      IsIncompleteTypeCheckEnvironment = false
-                      UseScriptResolutionRules = false
-                      LoadTime = DateTime.Now
-                      UnresolvedReferences = None
-                      OriginalLoadReferences = []
-                      ExtraProjectInfo = None
-                      ProjectId = None
-                      Stamp = None
-                  }
+                Ok { ProjectFileName = projectFilePath
+                     SourceFiles = fa |> List.filter isSourceFile |> List.map compileFilesToAbsolutePath |> Array.ofList
+                     OtherOptions = fa |> List.filter (isSourceFile >> not) |> Array.ofList
+                     ReferencedProjects = [||]
+                     IsIncompleteTypeCheckEnvironment = false
+                     UseScriptResolutionRules = false
+                     LoadTime = DateTime.Now
+                     UnresolvedReferences = None
+                     OriginalLoadReferences = []
+                     ExtraProjectInfo = None
+                     ProjectId = None
+                     Stamp = None }
             | Result.Ok _ ->
-                Error ( "error getting FSC args from msbuild info")
+                Error "error getting FSC args from msbuild info"
             | Result.Error error ->
                 Error (sprintf "error getting FSC args from msbuild info, %A" error)
         | Result.Ok r ->

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -44,37 +44,38 @@ module Lint =
 
     /// Optional parameters that can be provided to the linter.
     [<NoEquality; NoComparison>]
-    type OptionalLintParameters =
-        { /// Cancels a lint in progress.
-          CancellationToken: CancellationToken option
+    type OptionalLintParameters = {
+        /// Cancels a lint in progress.
+        CancellationToken: CancellationToken option
 
-          /// Lint configuration to use.
-          /// Can either specify a full configuration object, or a path to a file to load the configuration from.
-          /// You can also explicitly specify the default configuration.
-          Configuration: ConfigurationParam
+        /// Lint configuration to use.
+        /// Can either specify a full configuration object, or a path to a file to load the configuration from.
+        /// You can also explicitly specify the default configuration.
+        Configuration: ConfigurationParam
 
-          /// This function will be called every time the linter finds a broken rule.
-          ReceivedWarning: (Suggestion.LintWarning -> unit) option
+        /// This function will be called every time the linter finds a broken rule.
+        ReceivedWarning: (Suggestion.LintWarning -> unit) option
 
-          ReportLinterProgress: (ProjectProgress -> unit) option
+        ReportLinterProgress: (ProjectProgress -> unit) option
 
-          ReleaseConfiguration : string option }
-
+        ReleaseConfiguration : string option
+    } with
         static member Default: OptionalLintParameters
 
     /// If your application has already parsed the F# source files using `FSharp.Compiler.Services`
     /// you want to lint then this can be used to provide the parsed information to prevent the
     /// linter from parsing the file again.
     [<NoEquality; NoComparison>]
-    type ParsedFileInformation =
-        { /// File represented as an AST.
-          Ast: FSharp.Compiler.SyntaxTree.ParsedInput
+    type ParsedFileInformation = {
+        /// File represented as an AST.
+        Ast: FSharp.Compiler.SyntaxTree.ParsedInput
 
-          /// Contents of the file.
-          Source: string
+        /// Contents of the file.
+        Source: string
 
-          /// Optional results of inferring the types on the AST (allows for a more accurate lint).
-          TypeCheckResults: FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults option }
+        /// Optional results of inferring the types on the AST (allows for a more accurate lint).
+        TypeCheckResults: FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults option
+    }
 
     type BuildFailure = | InvalidProjectFileMessage of string
 

--- a/src/FSharpLint.Core/Framework/HintParser.fs
+++ b/src/FSharpLint.Core/Framework/HintParser.fs
@@ -331,8 +331,7 @@ module HintParser =
                 let map = Dictionary<_, _>()
 
                 transposed
-                |> List.choose
-                    (function
+                |> List.choose (function
                     | HintNode(expr, depth, rest) -> Some(getKey expr, expr, depth, rest)
                     | EndOfHint(_) -> None)
                 |> List.filter (isAnyMatch >> not)
@@ -341,8 +340,7 @@ module HintParser =
 
                 let anyMatches =
                     transposed
-                    |> List.choose
-                        (function
+                    |> List.choose (function
                         | HintNode(expr, depth, rest) ->
                             match (getKey expr, expr) with
                             | (SyntaxHintNode.Wildcard as key), HintExpr(Expression.Wildcard)
@@ -373,8 +371,7 @@ module HintParser =
 
                 let matchedHints =
                     transposed
-                    |> Seq.choose
-                        (function
+                    |> Seq.choose (function
                         | HintNode(_) -> None
                         | EndOfHint(hint) -> Some(hint))
                     |> Seq.toList

--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -43,13 +43,13 @@ type LineRuleParams =
       GlobalConfig : GlobalRuleConfig }
 
 type RuleMetadata<'config> =
-  { Name : string
-    Identifier : string
-    RuleConfig : 'config }
+    { Name : string
+      Identifier : string
+      RuleConfig : 'config }
 
 type AstNodeRuleConfig =
-  { Runner : AstNodeRuleParams -> WarningDetails []
-    Cleanup : unit -> unit }
+    { Runner : AstNodeRuleParams -> WarningDetails []
+      Cleanup : unit -> unit }
 
 type NamingCase =
     | PascalCase = 0

--- a/src/FSharpLint.Core/Framework/Utilities.fs
+++ b/src/FSharpLint.Core/Framework/Utilities.fs
@@ -20,7 +20,7 @@ module Dictionary =
             dict.Remove(key) |> ignore
 
         dict.Add(key, value)
-        
+
 module ExpressionUtilities =
 
     open System
@@ -78,17 +78,17 @@ module ExpressionUtilities =
     /// Converts a LongIdentWithDots to a String.
     let longIdentWithDotsToString (lidwd:LongIdentWithDots) =
         lidwd.Lid |> longIdentToString
-        
+
     /// Tries to find the source code within a given range.
     let tryFindTextOfRange (range:range) (text:string) =
         let startIndex = findPos range.Start text
         let endIndex = findPos range.End text
 
         match (startIndex, endIndex) with
-        | Some(startIndex), Some(endIndex) -> 
+        | Some(startIndex), Some(endIndex) ->
             text.Substring(startIndex, endIndex - startIndex) |> Some
         | _ -> None
-        
+
     let getLeadingSpaces (range:range) (text:string) =
         let range = mkRange "" (mkPos range.StartLine 0) range.End
         tryFindTextOfRange range text
@@ -100,11 +100,11 @@ module ExpressionUtilities =
 
     /// Converts a AsynType to its string representation.
     let synTypeToString (text:string) = function
-    | SynType.Tuple _ as synType ->
-        tryFindTextOfRange synType.Range text
-        |> Option.map (fun x -> "(" + x + ")")
-    | other ->
-        tryFindTextOfRange other.Range text
+        | SynType.Tuple _ as synType ->
+            tryFindTextOfRange synType.Range text
+            |> Option.map (fun x -> "(" + x + ")")
+        | other ->
+            tryFindTextOfRange other.Range text
 
     /// Converts a list of type args to its string representation.
     let typeArgsToString (text:string) (typeArgs:SynType list) =
@@ -112,11 +112,11 @@ module ExpressionUtilities =
         if typeStrings.Length = typeArgs.Length
         then typeStrings |> String.concat "," |> Some
         else None
-        
+
     /// Counts the number of comment lines preceeding the given range of text.
     let countPrecedingCommentLines (text:string) (startPos:pos) (endPos:pos) =
         let range = mkRange "" startPos endPos
-        
+
         tryFindTextOfRange range text
         |> Option.map (fun preceedingText ->
             let lines =
@@ -127,24 +127,24 @@ module ExpressionUtilities =
             |> Array.takeWhile (fun line -> line.TrimStart().StartsWith("//"))
             |> Array.length)
         |> Option.defaultValue 0
-        
+
     let rangeContainsOtherRange (containingRange:range) (range:range) =
         range.StartLine >= containingRange.StartLine && range.EndLine <= containingRange.EndLine
-        
+
 module String =
-    
+
     open System.IO
-    
+
     let toLines input =
         let lines = ResizeArray()
         use reader = new StringReader(input)
 
-        let readLine () = 
+        let readLine () =
             match reader.ReadLine() with
             | null -> None
             | line -> Some line
 
-        let rec iterateLines currentLine i = 
+        let rec iterateLines currentLine i =
             match currentLine with
             | Some line ->
                 let nextLine = readLine ()
@@ -156,5 +156,5 @@ module String =
             | None -> ()
 
         iterateLines (readLine ()) 0
-        
+
         lines.ToArray()

--- a/src/FSharpLint.Core/Rules/Conventions/Binding/BindingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Binding/BindingHelper.fs
@@ -11,4 +11,3 @@ let isLetBinding i (syntaxArray:AbstractSyntaxArray.Node []) (skipArray:Abstract
         | AstNode.Expression(SynExpr.LetOrUse(_, false, _, _, _)) -> true
         | _ -> false
     else false
- 

--- a/src/FSharpLint.Core/Rules/Conventions/FunctionReimplementation/ReimplementsFunction.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FunctionReimplementation/ReimplementsFunction.fs
@@ -14,7 +14,7 @@ let private validateLambdaIsNotPointless (text:string) lambda range =
             match expression with
             | SynExpr.App(_, _, expression, SynExpr.Ident(identifier), _)
                 when identifier.idText = parameter.idText ->
-                    isFunctionPointless expression parameters
+                isFunctionPointless expression parameters
             | _ -> None
         | None :: _ -> None
         | [] ->

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/LiteralNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/LiteralNames.fs
@@ -10,10 +10,10 @@ let private getIdentifiers (args:AstNodeRuleParams) =
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, attributes, _, _, pattern, _, _, _, _)) ->
         if isLiteral attributes then
             let rec getLiteralIdents = function
-            | SynPat.Named(_, identifier, _, _, _) ->
-                (identifier, identifier.idText, None) |> Array.singleton
-            | SynPat.Paren(p, _) -> getLiteralIdents p
-            | _ -> Array.empty
+                | SynPat.Named(_, identifier, _, _, _) ->
+                    (identifier, identifier.idText, None) |> Array.singleton
+                | SynPat.Paren(p, _) -> getLiteralIdents p
+                | _ -> Array.empty
 
             getLiteralIdents pattern
         else

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamespaceNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamespaceNames.fs
@@ -12,8 +12,8 @@ let private getIdentifiers (args:AstNodeRuleParams) =
             identifier
             |> List.map (fun identifier -> (identifier, identifier.idText, None))
             |> List.toArray
-         else
-             Array.empty
+        else
+            Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -273,10 +273,10 @@ let checkIfPublic isCurrentlyPublic = function
 
 let isModule (moduleKind:SynModuleOrNamespaceKind) =
     match moduleKind with
-        | AnonModule
-        | NamedModule -> true
-        | DeclaredNamespace
-        | GlobalNamespace -> false
+    | AnonModule
+    | NamedModule -> true
+    | DeclaredNamespace
+    | GlobalNamespace -> false
 
 /// Is module name implicitly created from file name?
 let isImplicitModule (SynModuleOrNamespace.SynModuleOrNamespace(longIdent, _, moduleKind, _, _, _, _, range)) =

--- a/src/FSharpLint.Core/Rules/Conventions/RecursiveAsyncFunction.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/RecursiveAsyncFunction.fs
@@ -10,7 +10,7 @@ open FSharpLint.Framework.Rules
 let private isAsyncCompExpr = function
     | SynExpr.App (_, _, (SynExpr.Ident compExprName), (SynExpr.CompExpr _), _)
         when compExprName.idText = "async" ->
-            true
+        true
     | _ -> false
 
 let rec private getIdentFromSynPat = function

--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInConstructor.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInConstructor.fs
@@ -8,9 +8,9 @@ open FSharpLint.Framework.Rules
 let runner (config:Helper.SourceLength.Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, _, _) as binding) ->
-       match identifierTypeFromValData valData with
-       | Constructor -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Constructor"
-       | _ -> Array.empty
+        match identifierTypeFromValData valData with
+        | Constructor -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Constructor"
+        | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInFunction.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInFunction.fs
@@ -8,9 +8,9 @@ open FSharpLint.Framework.Rules
 let runner (config:Helper.SourceLength.Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, _, _) as binding) ->
-       match identifierTypeFromValData valData with
-       | Function -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Function"
-       | _ -> Array.empty
+        match identifierTypeFromValData valData with
+        | Function -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Function"
+        | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInMember.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInMember.fs
@@ -8,9 +8,9 @@ open FSharpLint.Framework.Rules
 let runner (config:Helper.SourceLength.Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, _, _) as binding) ->
-       match identifierTypeFromValData valData with
-       | Member -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Member"
-       | _ -> Array.empty
+        match identifierTypeFromValData valData with
+        | Member -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Member"
+        | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInProperty.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInProperty.fs
@@ -8,9 +8,9 @@ open FSharpLint.Framework.Rules
 let runner (config:Helper.SourceLength.Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, _, _) as binding) ->
-       match identifierTypeFromValData valData with
-       | Property -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Property"
-       | _ -> Array.empty
+        match identifierTypeFromValData valData with
+        | Property -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Property"
+        | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInValue.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/MaxLinesInValue.fs
@@ -8,9 +8,9 @@ open FSharpLint.Framework.Rules
 let runner (config:Helper.SourceLength.Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, _, _) as binding) ->
-       match identifierTypeFromValData valData with
-       | Value -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Value"
-       | _ -> Array.empty
+        match identifierTypeFromValData valData with
+        | Value -> Helper.SourceLength.checkSourceLengthRule config binding.RangeOfBindingAndRhs "Value"
+        | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Formatting/TupleFormatting/TupleIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/TupleFormatting/TupleIndentation.fs
@@ -19,10 +19,10 @@ let checkTupleIndentation _ (tupleExprs:SynExpr list) _ _ =
     |> Array.pairwise
     |> Array.choose (fun (expr, nextExpr) ->
         if expr.Range.StartColumn <> nextExpr.Range.StartColumn then
-           { Range = mkRange "" expr.Range.Start nextExpr.Range.End
-             Message = Resources.GetString("RulesFormattingTupleIndentationError")
-             SuggestedFix = None
-             TypeChecks = [] } |> Some
+            { Range = mkRange "" expr.Range.Start nextExpr.Range.End
+              Message = Resources.GetString("RulesFormattingTupleIndentationError")
+              SuggestedFix = None
+              TypeChecks = [] } |> Some
         else
             None)
 

--- a/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
+++ b/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
@@ -302,13 +302,13 @@ module private MatchExpression =
         match (arguments.Expression, arguments.Hint) with
         | AstNode.Expression(SynExpr.IfThenElse(cond, expr, None, _, _, _, _)),
             Expression.If(hintCond, hintExpr, None) ->
-                arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
-                (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr)
+            arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
+            (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr)
         | AstNode.Expression(SynExpr.IfThenElse(cond, expr, Some(elseExpr), _, _, _, _)),
             Expression.If(hintCond, hintExpr, Some(Expression.Else(hintElseExpr))) ->
-                arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
-                (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr) &&~
-                (arguments.SubHint(Expression elseExpr, hintElseExpr) |> matchHintExpr)
+            arguments.SubHint(Expression cond, hintCond) |> matchHintExpr &&~
+            (arguments.SubHint(Expression expr, hintExpr) |> matchHintExpr) &&~
+            (arguments.SubHint(Expression elseExpr, hintElseExpr) |> matchHintExpr)
         | _ -> NoMatch
 
     and matchLambda arguments =

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -41,22 +41,22 @@ module ContextBuilder =
     let private createAbsoluteAndOffsetOverridesBasedOnFirst (ranges:range list) =
         match ranges with
         | (first::others) ->
-             let expectedIndentation = first.StartColumn
-             others |> List.map (fun other -> (other.StartLine, (true, expectedIndentation)))
+            let expectedIndentation = first.StartColumn
+            others |> List.map (fun other -> (other.StartLine, (true, expectedIndentation)))
         | _ -> []
 
     let private indentationOverridesForNode (node:AstNode) =
         match node with
         | TypeDefinition (SynTypeDefn.TypeDefn(_, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Record(_, fields, _), _), _, _)) ->
-             fields
-             |> List.map (fun (SynField.Field (_, _, _, _, _, _, _, range)) -> range)
-             |> firstRangePerLine
-             |> createAbsoluteAndOffsetOverridesBasedOnFirst
+            fields
+            |> List.map (fun (SynField.Field (_, _, _, _, _, _, _, range)) -> range)
+            |> firstRangePerLine
+            |> createAbsoluteAndOffsetOverridesBasedOnFirst
         | Expression (SynExpr.Tuple (_, exprs, _, _)) ->
             exprs
-             |> List.map (fun expr -> expr.Range)
-             |> firstRangePerLine
-             |> createAbsoluteAndOffsetOverridesBasedOnFirst
+            |> List.map (fun expr -> expr.Range)
+            |> firstRangePerLine
+            |> createAbsoluteAndOffsetOverridesBasedOnFirst
         | Expression (SynExpr.Record(recordFields=recordFields)) ->
             recordFields
             |> List.map (fun ((fieldName, _), _, _) -> fieldName.Range)

--- a/tests/FSharpLint.Benchmarks/FSharpLint.Benchmarks.fsproj
+++ b/tests/FSharpLint.Benchmarks/FSharpLint.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Benchmark.fs" />


### PR DESCRIPTION
I configured MSBuild to run the linter some time ago, but forgot to configure the tool itself to be installed. This should address the issue causing the build to fail in #404. Additionally, I updated `IgnoreExitCode` in the MSBuild task to `false`; now the PR check will fail if there are any linting errors.