### PR TITLE
Fix some bugs with indentation rules

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+##### 0.14.2 - May 20 2020
+
+* Fixes for exceptional indentation cases
+
 ##### 0.14.1 - May 19 2020
 
 * .NET Core 3.1 support [@milbrandt]

--- a/docs-gen/markdown/rules/FL0006.md
+++ b/docs-gen/markdown/rules/FL0006.md
@@ -19,6 +19,11 @@ Uses the `numIndentationSpaces` global setting.
 	[lang=javascript]
     {
         "patternMatchClauseIndentation": {
-            "enabled": false
+            "enabled": false,
+            "config": {
+              "allowSingleLineLambda": false
+            }
         }
     }
+
+* *allowSingleLineLambda* - whether or not to allow single-line lambda pattern matches

--- a/docs/rules/FL0006.html
+++ b/docs/rules/FL0006.html
@@ -41,13 +41,22 @@
 <span class="l">3: </span>
 <span class="l">4: </span>
 <span class="l">5: </span>
+<span class="l">6: </span>
+<span class="l">7: </span>
+<span class="l">8: </span>
 </pre></td>
 <td class="snippet"><pre class="fssnip highlighted"><code lang="javascript">{
     <span class="s">"patternMatchClauseIndentation"</span>: {
-        <span class="s">"enabled"</span>: <span class="k">false</span>
+        <span class="s">"enabled"</span>: <span class="k">false</span>,
+        <span class="s">"config"</span>: {
+          <span class="s">"allowSingleLineLambda"</span>: <span class="k">false</span>
+        }
     }
 }
 </code></pre></td></tr></table>
+<ul>
+<li><em>allowSingleLineLambda</em> - whether or not to allow single-line lambda pattern matches</li>
+</ul>
 
           
         </div>

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -152,14 +152,14 @@ with
 type PatternMatchFormattingConfig =
     { patternMatchClausesOnNewLine : EnabledConfig option
       patternMatchOrClausesOnNewLine : EnabledConfig option
-      patternMatchClauseIndentation : EnabledConfig option
+      patternMatchClauseIndentation : RuleConfig<PatternMatchClauseIndentation.Config> option
       patternMatchExpressionIndentation : EnabledConfig option }
 with
     member this.Flatten() =
         [|
             this.patternMatchClausesOnNewLine |> Option.bind (constructRuleIfEnabled PatternMatchClausesOnNewLine.rule)
             this.patternMatchOrClausesOnNewLine |> Option.bind (constructRuleIfEnabled PatternMatchOrClausesOnNewLine.rule)
-            this.patternMatchClauseIndentation |> Option.bind (constructRuleIfEnabled PatternMatchClauseIndentation.rule)
+            this.patternMatchClauseIndentation |> Option.bind (constructRuleWithConfig PatternMatchClauseIndentation.rule)
             this.patternMatchExpressionIndentation |> Option.bind (constructRuleIfEnabled PatternMatchExpressionIndentation.rule)
         |] |> Array.choose id
 
@@ -369,7 +369,7 @@ type Configuration =
       TupleParentheses : EnabledConfig option
       PatternMatchClausesOnNewLine : EnabledConfig option
       PatternMatchOrClausesOnNewLine : EnabledConfig option
-      PatternMatchClauseIndentation : EnabledConfig option
+      PatternMatchClauseIndentation : RuleConfig<PatternMatchClauseIndentation.Config> option
       PatternMatchExpressionIndentation : EnabledConfig option
       RecursiveAsyncFunction : EnabledConfig option
       RedundantNewKeyword : EnabledConfig option
@@ -578,7 +578,7 @@ let flattenConfig (config:Configuration) =
             config.TupleParentheses |> Option.bind (constructRuleIfEnabled TupleParentheses.rule)
             config.PatternMatchClausesOnNewLine |> Option.bind (constructRuleIfEnabled PatternMatchClausesOnNewLine.rule)
             config.PatternMatchOrClausesOnNewLine |> Option.bind (constructRuleIfEnabled PatternMatchOrClausesOnNewLine.rule)
-            config.PatternMatchClauseIndentation |> Option.bind (constructRuleIfEnabled PatternMatchClauseIndentation.rule)
+            config.PatternMatchClauseIndentation |> Option.bind (constructRuleWithConfig PatternMatchClauseIndentation.rule)
             config.PatternMatchExpressionIndentation |> Option.bind (constructRuleIfEnabled PatternMatchExpressionIndentation.rule)
             config.RecursiveAsyncFunction |> Option.bind (constructRuleIfEnabled RecursiveAsyncFunction.rule)
             config.RedundantNewKeyword |> Option.bind (constructRuleIfEnabled RedundantNewKeyword.rule)

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -163,7 +163,7 @@ module Lint =
                   FilePath = filePath
                   FileContent = fileContent
                   Lines = lines
-                  GlobalConfig =  globalConfig }
+                  GlobalConfig = globalConfig }
 
             let indentationError =
                 lineRules.IndentationRule

--- a/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
@@ -8,36 +8,42 @@ open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 open FSharpLint.Rules.Helper
 
-let check (args:AstNodeRuleParams) matchExprRange (clauses:SynMatchClause list) isLambda =
+[<RequireQualifiedAccess>]
+type Config = { AllowSingleLineLambda : bool }
+
+let check (config:Config) (args:AstNodeRuleParams) matchExprRange (clauses:SynMatchClause list) isLambda =
     let matchStartIndentation = ExpressionUtilities.getLeadingSpaces matchExprRange args.FileContent
 
     let indentationLevelError =
-        clauses
-        |> List.tryHead
-        |> Option.bind (fun firstClause ->
-            let clauseIndentation = ExpressionUtilities.getLeadingSpaces firstClause.Range args.FileContent
-            if isLambda then
-                if clauseIndentation <> matchStartIndentation + args.GlobalConfig.numIndentationSpaces then
+        if isLambda && config.AllowSingleLineLambda && clauses |> List.forall (fun clause -> clause.Range.StartLine = matchExprRange.StartLine) then
+            None
+        else
+            clauses
+            |> List.tryHead
+            |> Option.bind (fun firstClause ->
+                let clauseIndentation = ExpressionUtilities.getLeadingSpaces firstClause.Range args.FileContent
+                if isLambda then
+                    if clauseIndentation <> matchStartIndentation + args.GlobalConfig.numIndentationSpaces then
+                        { Range = firstClause.Range
+                          Message = Resources.GetString("RulesFormattingLambdaPatternMatchClauseIndentationError")
+                          SuggestedFix = None
+                          TypeChecks = [] } |> Some
+                    else
+                        None
+                elif clauseIndentation <> matchStartIndentation then
                     { Range = firstClause.Range
-                      Message = Resources.GetString("RulesFormattingLambdaPatternMatchClauseIndentationError")
+                      Message = Resources.GetString("RulesFormattingPatternMatchClauseIndentationError")
                       SuggestedFix = None
                       TypeChecks = [] } |> Some
                 else
-                    None
-            elif clauseIndentation <> matchStartIndentation then
-                { Range = firstClause.Range
-                  Message = Resources.GetString("RulesFormattingPatternMatchClauseIndentationError")
-                  SuggestedFix = None
-                  TypeChecks = [] } |> Some
-            else
-                None)
+                    None)
 
     let consistentIndentationErrors =
         clauses
         |> List.toArray
         |> Array.map (fun clause -> (clause, ExpressionUtilities.getLeadingSpaces clause.Range args.FileContent))
         |> Array.pairwise
-        |> Array.choose (fun ((clauseOne, clauseOneSpaces), (clauseTwo, clauseTwoSpaces)) ->
+        |> Array.choose (fun ((_, clauseOneSpaces), (clauseTwo, clauseTwoSpaces)) ->
             if clauseOneSpaces <> clauseTwoSpaces then
                 { Range = clauseTwo.Range
                   Message = Resources.GetString("RulesFormattingPatternMatchClauseSameIndentationError")
@@ -52,10 +58,10 @@ let check (args:AstNodeRuleParams) matchExprRange (clauses:SynMatchClause list) 
     |]
     |> Array.concat
 
-let runner (args:AstNodeRuleParams) = PatternMatchFormatting.isActualPatternMatch args check
+let runner (config:Config) (args:AstNodeRuleParams) = PatternMatchFormatting.isActualPatternMatch args (check config)
 
-let rule =
+let rule config =
     { Name = "PatternMatchClauseIndentation"
       Identifier = Identifiers.PatternMatchClauseIndentation
-      RuleConfig = { AstNodeRuleConfig.Runner = runner; Cleanup = ignore } }
+      RuleConfig = { AstNodeRuleConfig.Runner = runner config; Cleanup = ignore } }
     |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -91,10 +91,13 @@ module ContextBuilder =
             Map.add line indentationOverride current) current
 
 let checkIndentation (expectedSpaces:int) (line:string) (lineNumber:int) (indentationOverrides:Map<int,bool*int>) =
-    let numLeadingSpaces = line.Length - line.TrimStart().Length
+    let lineTrimmedStart = line.TrimStart()
+    let numLeadingSpaces = line.Length - lineTrimmedStart.Length
     let range = mkRange "" (mkPos lineNumber 0) (mkPos lineNumber numLeadingSpaces)
 
-    if indentationOverrides.ContainsKey lineNumber then
+    if lineTrimmedStart.StartsWith "//" || lineTrimmedStart.StartsWith "(*" then
+        None
+    elif indentationOverrides.ContainsKey lineNumber then
         match indentationOverrides.[lineNumber] with
         | (true, expectedIndentation) ->
             if numLeadingSpaces <> expectedIndentation then

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -29,6 +29,7 @@ module ContextBuilder =
                 (other::items)
 
         helper [] seqExpr
+        |> List.rev
 
     let private createAbsoluteAndOffsetOverrides expectedIndentation (rangeToUpdate:range) =
         let absoluteOverride = (rangeToUpdate.StartLine, (true, expectedIndentation))

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/PatternMatchFormatting/PatternMatchClauseIndentation.fs
@@ -5,7 +5,7 @@ open FSharpLint.Rules
 
 [<TestFixture>]
 type TestFormattingPatternMatchClauseIndentation() =
-    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(PatternMatchClauseIndentation.rule)
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(PatternMatchClauseIndentation.rule { PatternMatchClauseIndentation.Config.AllowSingleLineLambda = false })
 
     [<Test>]
     member this.``Error for pattern match clauses at different indentation``() =
@@ -125,4 +125,21 @@ match "x" with
           this.Parse """fun struct(x, y) -> ()"""
 
           Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Error for single-line lambda pattern match when not allowed``() =
+        this.Parse """let isAnyMatch = function ((SyntaxHintNode.Wildcard | SyntaxHintNode.Variable), _, _, _) -> true | _ -> false"""
+
+        Assert.IsTrue(this.ErrorExistsAt(1, 26))
+
+[<TestFixture>]
+type TestFormattingPatternMatchClauseIndentationAllowSingleLineLambda() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(PatternMatchClauseIndentation.rule { PatternMatchClauseIndentation.Config.AllowSingleLineLambda = true })
+
+    [<Test>]
+    member this.``No error for single-line lambda pattern match when allowed``() =
+        this.Parse """let isAnyMatch = function ((SyntaxHintNode.Wildcard | SyntaxHintNode.Variable), _, _, _) -> true | _ -> false"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
 

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/PatternMatchFormatting/PatternMatchExpressionIndentation.fs
@@ -13,9 +13,9 @@ type TestFormattingPatternMatchExpressionIndentation() =
 module Program
 
 match 1 with
-| 1 -> 
+| 1 ->
 true
-| 2 -> 
+| 2 ->
     false
 """
 
@@ -27,9 +27,9 @@ true
 module Program
 
 match 1 with
-| 1 -> 
+| 1 ->
     true
-| 2 -> 
+| 2 ->
     false
 """
 

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -201,3 +201,50 @@ let comparer =
               reversed.CompareTo (rev s2) }"""
 
         Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for record with comment``() =
+        this.Parse """
+    type CurrentNode =
+        { Node: AstNode
+          ChildNodes: AstNode list
+
+          /// A list of parent nodes e.g. parent, grand parent, grand grand parent.
+          Breadcrumbs: AstNode list }"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional nested records indentation``() =
+        this.Parse """
+    { LoadedRules.GlobalConfig = getGlobalConfig config.Global
+      DeprecatedRules = deprecatedAllRules
+      AstNodeRules = astNodeRules.ToArray()
+      LineRules =
+        { GenericLineRules = lineRules.ToArray()
+          IndentationRule = indentationRule
+          NoTabCharactersRule = noTabCharactersRule } }"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional list indentation``() =
+        this.Parse """
+let opchars =
+    [ '>';'<';'+';'-';'*';'=';'~';'%';'&';'|';'@'
+        '#';'^';'!';'?';'/';'.';':';',' ]"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional match guard indentation``() =
+        this.Parse """
+match args.AstNode with
+| AstNode.Binding(SynBinding.Binding(_, _, _, isMutable, _, _, _, pattern, _, expr, range, _))
+        when Helper.Binding.isLetBinding args.NodeIndex args.SyntaxArray args.SkipArray
+        && not isMutable ->
+    checkForUselessBinding args.CheckInfo pattern expr range
+| _ ->
+    Array.empty"""
+
+        Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -242,7 +242,7 @@ let opchars =
 match args.AstNode with
 | AstNode.Binding(SynBinding.Binding(_, _, _, isMutable, _, _, _, pattern, _, expr, range, _))
         when Helper.Binding.isLetBinding args.NodeIndex args.SyntaxArray args.SkipArray
-        && not isMutable ->
+             && not isMutable ->
     checkForUselessBinding args.CheckInfo pattern expr range
 | _ ->
     Array.empty"""

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -228,11 +228,11 @@ let comparer =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``No error for exceptional list indentation``() =
+    member this.``No error for exceptional list indentation with multiple items per line``() =
         this.Parse """
 let opchars =
     [ '>';'<';'+';'-';'*';'=';'~';'%';'&';'|';'@'
-        '#';'^';'!';'?';'/';'.';':';',' ]"""
+      '#';'^';'!';'?';'/';'.';':';',' ]"""
 
         Assert.IsTrue(this.NoErrorsExist)
 


### PR DESCRIPTION
Fix several bugs with indentation rules:
- Handle lists with multiple items on same line
- Ignore lines starting with comments
- Handle nested record expression indentation
- Update PatternMatchClauseIndentation rule with config to allow lambda pattern match on same line