### PR TITLE
Fix more indentation issues

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-fsharplint": {
-      "version": "0.14.1",
+      "version": "0.14.2",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/fsharplint.json
+++ b/fsharplint.json
@@ -21,8 +21,13 @@
         "patternMatchFormatting": {
             "patternMatchClausesOnNewLine": { "enabled": false },
             "patternMatchOrClausesOnNewLine": { "enabled": false },
-            "patternMatchClauseIndentation": { "enabled": false },
-            "patternMatchExpressionIndentation": { "enabled": false }
+            "patternMatchClauseIndentation": {
+              "enabled": true,
+              "config": {
+                "allowSingleLineLambda": false
+              }
+            },
+            "patternMatchExpressionIndentation": { "enabled": true }
         }
     },
     "conventions": {

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -252,7 +252,9 @@ module Lint =
                     |> Seq.map typeCheckSuggestion
                     |> Async.Parallel
                     |> runSynchronously
-                    |> Array.iter (function Some suggestion -> suggest suggestion | None -> ())
+                    |> Array.iter (function
+                        | Some suggestion -> suggest suggestion
+                        | None -> ())
                 with
                 | :? TimeoutException -> () // Do nothing.
         with

--- a/src/FSharpLint.Core/Framework/HintParser.fs
+++ b/src/FSharpLint.Core/Framework/HintParser.fs
@@ -322,9 +322,11 @@ module HintParser =
 
             transposeHead [] hintLists
 
-        let isAnyMatch = function ((SyntaxHintNode.Wildcard | SyntaxHintNode.Variable), _, _, _) -> true | _ -> false
+        let isAnyMatch = function
+            | ((SyntaxHintNode.Wildcard | SyntaxHintNode.Variable), _, _, _) -> true
+            | _ -> false
 
-        let getHints items = items |> Seq.map (function (_, _, _, hint) -> hint) |> Seq.toList
+        let getHints items = items |> Seq.map (fun (_, _, _, hint) -> hint) |> Seq.toList
 
         let mergeHints hints =
             let rec getEdges transposed =
@@ -460,14 +462,14 @@ module HintParser =
                 [ attempt pident
                   .>>. many (attempt (skipChar '.' >>. pident))
                   .>>. opt (skipChar '.' >>. pidentorop)
-                  |>> fun ((startIdent, idents), operator) ->
+                  |>> (fun ((startIdent, idents), operator) ->
                       let identifiers = startIdent::idents
                       match operator with
                       | Some(operator) -> identifiers@[operator]
-                      | None -> identifiers
+                      | None -> identifiers)
                   attempt (pidentorop |>> fun x -> [x])
                   plongident ]
-                |>> List.map charListToString
+            |>> List.map charListToString
 
     module StringAndCharacterLiterals =
         let private hexToCharacter hex =
@@ -551,6 +553,7 @@ module HintParser =
                   pnewline ]
 
         let private pstringelem, private pstringelemImpl = createParserForwardedToRef()
+
         do pstringelemImpl :=
             choice
                 [ attempt pstringchar

--- a/src/FSharpLint.Core/Framework/ParseFile.fs
+++ b/src/FSharpLint.Core/Framework/ParseFile.fs
@@ -12,18 +12,19 @@ module ParseFile =
 
     /// Information for a file to be linted that is given to the analysers.
     [<NoEquality; NoComparison>]
-    type FileParseInfo =
-        { /// Contents of the file.
-          Text: string
+    type FileParseInfo = {
+        /// Contents of the file.
+        Text: string
 
-          /// File represented as an AST.
-          Ast: ParsedInput
+        /// File represented as an AST.
+        Ast: ParsedInput
 
-          /// Optional results of inferring the types on the AST (allows for a more accurate lint).
-          TypeCheckResults: FSharpCheckFileResults option
+        /// Optional results of inferring the types on the AST (allows for a more accurate lint).
+        TypeCheckResults: FSharpCheckFileResults option
 
-          /// Path to the file.
-          File: string }
+        /// Path to the file.
+        File: string
+    }
 
     [<NoComparison>]
     type ParseFileFailure =

--- a/src/FSharpLint.Core/Framework/Suggestion.fs
+++ b/src/FSharpLint.Core/Framework/Suggestion.fs
@@ -5,30 +5,31 @@ open FSharp.Compiler.Range
 
 /// Information for consuming applications to provide an automated fix for a lint suggestion.
 [<NoEquality; NoComparison>]
-type SuggestedFix =
-    { /// Text to be replaced.
-      FromText: string
+type SuggestedFix = {
+    /// Text to be replaced.
+    FromText: string
 
-      /// Location of the text to be replaced.
-      FromRange: range
+    /// Location of the text to be replaced.
+    FromRange: range
 
-      /// Text to replace the `FromText`, i.e. the fix.
-      ToText: string }
+    /// Text to replace the `FromText`, i.e. the fix.
+    ToText: string
+}
 
 [<NoEquality; NoComparison>]
 type WarningDetails = {
-   /// Location of the code that prompted the suggestion.
-   Range: range
+    /// Location of the code that prompted the suggestion.
+    Range: range
 
-   /// Suggestion message to describe the possible problem to the user.
-   Message: string
+    /// Suggestion message to describe the possible problem to the user.
+    Message: string
 
-   /// Information to provide an automated fix.
-   SuggestedFix: Lazy<SuggestedFix option> option
+    /// Information to provide an automated fix.
+    SuggestedFix: Lazy<SuggestedFix option> option
 
-   /// Async type checks to be performed to confirm this suggestion is valid.
-   /// Suggestion is only considered valid when all type checks resolve to true.
-   TypeChecks: Async<bool> list
+    /// Async type checks to be performed to confirm this suggestion is valid.
+    /// Suggestion is only considered valid when all type checks resolve to true.
+    TypeChecks: Async<bool> list
 } with
     member internal this.WithTypeCheck typeCheck =
         match typeCheck with
@@ -37,19 +38,19 @@ type WarningDetails = {
 
 /// A lint "warning", sources the location of the warning with a suggestion on how it may be fixed.
 [<NoEquality; NoComparison>]
-type LintWarning =
-    {
-      /// Unique identifier for the rule that caused the warning.
-      RuleIdentifier: string
+type LintWarning = {
+    /// Unique identifier for the rule that caused the warning.
+    RuleIdentifier: string
 
-      /// Unique name for the rule that caused the warning.
-      RuleName: string
+    /// Unique name for the rule that caused the warning.
+    RuleName: string
 
-      /// Path to the file where the error occurs.
-      FilePath: string
+    /// Path to the file where the error occurs.
+    FilePath: string
 
-      /// Text that caused the error (the `Range` of the content of `FileName`).
-      ErrorText: string
+    /// Text that caused the error (the `Range` of the content of `FileName`).
+    ErrorText: string
 
-      /// Details for the warning.
-      Details: WarningDetails }
+    /// Details for the warning.
+    Details: WarningDetails
+}

--- a/src/FSharpLint.Core/Rules/Conventions/Binding/UselessBinding.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Binding/UselessBinding.fs
@@ -52,7 +52,7 @@ let private runner (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding(SynBinding.Binding(_, _, _, isMutable, _, _, _, pattern, _, expr, range, _))
             when Helper.Binding.isLetBinding args.NodeIndex args.SyntaxArray args.SkipArray
-            && not isMutable ->
+                 && not isMutable ->
         checkForUselessBinding args.CheckInfo pattern expr range
     | _ ->
         Array.empty

--- a/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
+++ b/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
@@ -60,7 +60,11 @@ let private matchLambdaArguments (hintArgs:HintParser.LambdaArg list) (actualArg
             List.zip hintArgs actualArgs
             |> List.map matchLambdaArgument
 
-        let allArgsMatch = matches |> List.forall (function LambdaArgumentMatch.NoMatch -> false | _ -> true)
+        let allArgsMatch =
+            matches
+            |> List.forall (function
+                | LambdaArgumentMatch.NoMatch -> false
+                | _ -> true)
 
         if allArgsMatch then
             matches
@@ -142,7 +146,9 @@ module private Precedence =
         | _ -> false
 
 let private filterParens astNodes =
-    let isNotParen = function AstNode.Expression(SynExpr.Paren(_)) -> false | _ -> true
+    let isNotParen = function
+        | AstNode.Expression(SynExpr.Paren(_)) -> false
+        | _ -> true
 
     List.filter isNotParen astNodes
 
@@ -420,8 +426,8 @@ module private MatchPattern =
             matchArray (pattern, hint)
 
     and private doPatternsMatch patterns hintExpressions =
-        List.length patterns = List.length hintExpressions &&
-            (patterns, hintExpressions) ||> List.forall2 (fun x y -> matchHintPattern (x, y))
+        (List.length patterns = List.length hintExpressions)
+        && (patterns, hintExpressions) ||> List.forall2 (fun x y -> matchHintPattern (x, y))
 
     and private matchList (pattern, hint) =
         match (pattern, hint) with
@@ -535,8 +541,9 @@ module private FormatHint =
             | HintExpr(Expression.Parentheses(hint)) -> "(" + toString (HintExpr hint) + ")"
             | HintPat(Pattern.Parentheses(hint)) -> "(" + toString (HintPat hint) + ")"
             | HintExpr(Expression.Lambda(arguments, LambdaBody(body))) ->
-                "fun " + lambdaArgumentsToString replace parentAstNode args matchedVariables arguments
-                    + " -> " + toString (HintExpr body)
+                "fun "
+                + lambdaArgumentsToString replace parentAstNode args matchedVariables arguments
+                + " -> " + toString (HintExpr body)
             | HintExpr(Expression.LambdaArg(argument)) ->
                 toString (HintExpr argument)
             | HintExpr(Expression.LambdaBody(body)) ->
@@ -565,7 +572,7 @@ module private FormatHint =
         else str
     and private lambdaArgumentsToString replace parentAstNode args matchedVariables (arguments:LambdaArg list) =
         arguments
-        |> List.map (function LambdaArg(expr) -> toString replace parentAstNode args matchedVariables None (HintExpr expr))
+        |> List.map (fun (LambdaArg expr) -> toString replace parentAstNode args matchedVariables None (HintExpr expr))
         |> String.concat " "
 
 let private hintError typeChecks hint (args:AstNodeRuleParams) range matchedVariables parentAstNode =

--- a/src/FSharpLint.Core/Rules/Typography/Indentation.fs
+++ b/src/FSharpLint.Core/Rules/Typography/Indentation.fs
@@ -85,7 +85,7 @@ module ContextBuilder =
             |> List.map (fun expr -> expr.Range)
             |> firstRangePerLine
             |> createAbsoluteAndOffsetOverridesBasedOnFirst
-        | Expression(SynExpr.App(funcExpr=(SynExpr.App(isInfix=isInfix; argExpr=innerArg; funcExpr=funcExpr)); argExpr=outerArg))
+        | Expression (SynExpr.App(funcExpr=(SynExpr.App(isInfix=isInfix; argExpr=innerArg; funcExpr=funcExpr)); argExpr=outerArg))
             when isInfix && outerArg.Range.EndLine <> innerArg.Range.StartLine ->
             match funcExpr with
             | SynExpr.Ident ident when ident.idText = "op_ColonEquals" ->
@@ -94,12 +94,22 @@ module ContextBuilder =
             | _ ->
                 let expectedIndentation = innerArg.Range.StartColumn
                 createAbsoluteAndOffsetOverrides expectedIndentation outerArg.Range
-        | Expression(SynExpr.ObjExpr(bindings=bindings; newExprRange=newExprRange)) ->
+        | Expression (SynExpr.ObjExpr(bindings=bindings; newExprRange=newExprRange)) ->
             let expectedIndentation = newExprRange.StartColumn + 4
             bindings
             |> List.map (fun binding -> binding.RangeOfBindingAndRhs)
             |> firstRangePerLine
             |> List.collect (createAbsoluteAndOffsetOverrides expectedIndentation)
+        | Pattern (SynPat.Tuple (elementPats=elemPats)) ->
+            elemPats
+            |> List.map (fun pat -> pat.Range)
+            |> firstRangePerLine
+            |> createAbsoluteAndOffsetOverridesBasedOnFirst
+        | Pattern (SynPat.Record (fieldPats=fieldPats)) ->
+            fieldPats
+            |> List.map (fun ((_, fieldIdent), _) -> fieldIdent.idRange)
+            |> firstRangePerLine
+            |> createAbsoluteAndOffsetOverridesBasedOnFirst
         | _ -> []
 
     let builder current node =

--- a/src/FSharpLint.Core/Rules/Typography/TrailingWhitespaceOnLine.fs
+++ b/src/FSharpLint.Core/Rules/Typography/TrailingWhitespaceOnLine.fs
@@ -26,10 +26,10 @@ let private doesStringNotEndWithWhitespace (config:Config) (str:string) =
     | (_, isOneSpaceAllowedAfterOperator) when isOneSpaceAllowedAfterOperator ->
         let trimmedStr = str.TrimEnd()
 
-        trimmedStr.Length = str.Length ||
-            (str.Length - trimmedStr.Length = 1 &&
-                trimmedStr.Length > 0 &&
-                isSymbol trimmedStr.[trimmedStr.Length - 1])
+        (trimmedStr.Length = str.Length)
+        || (str.Length - trimmedStr.Length = 1
+            && trimmedStr.Length > 0
+            && isSymbol trimmedStr.[trimmedStr.Length - 1])
     | _ ->
         str.TrimEnd().Length = str.Length
 

--- a/tests/FSharpLint.Core.Tests/Framework/TestHintParser.fs
+++ b/tests/FSharpLint.Core.Tests/Framework/TestHintParser.fs
@@ -20,32 +20,32 @@ type TestMergeSyntaxTrees() =
             dictionary
 
         match (run phint "List.map id ===> id", run phint "List.map woof ===> woof") with
-            | Success(hint, _, _), Success(hint2, _, _) ->
-                let expectedEdges =
-                    { Lookup =
-                        [ (Utilities.hash2 SyntaxHintNode.Identifier "map",
-                           { Edges =
-                               { Lookup =
-                                   [ (Utilities.hash2 SyntaxHintNode.Identifier "woof",
-                                      { Edges = Edges.Empty
-                                        MatchedHint = [hint2] })
-                                     (Utilities.hash2 SyntaxHintNode.Identifier "id",
-                                      { Edges = Edges.Empty
-                                        MatchedHint = [hint] }) ] |> toDictionary
-                                 AnyMatch = [] }
-                             MatchedHint = [] }) ] |> toDictionary
-                      AnyMatch = [] }
+        | Success(hint, _, _), Success(hint2, _, _) ->
+            let expectedEdges =
+                { Lookup =
+                    [ (Utilities.hash2 SyntaxHintNode.Identifier "map",
+                       { Edges =
+                           { Lookup =
+                               [ (Utilities.hash2 SyntaxHintNode.Identifier "woof",
+                                  { Edges = Edges.Empty
+                                    MatchedHint = [hint2] })
+                                 (Utilities.hash2 SyntaxHintNode.Identifier "id",
+                                  { Edges = Edges.Empty
+                                    MatchedHint = [hint] }) ] |> toDictionary
+                             AnyMatch = [] }
+                         MatchedHint = [] }) ] |> toDictionary
+                  AnyMatch = [] }
 
-                let expectedRoot =
-                    { Lookup =
-                        [(Utilities.hash2 SyntaxHintNode.FuncApp 0,
-                          { Edges = expectedEdges; MatchedHint = [] })] |> toDictionary
-                      AnyMatch = [] }
+            let expectedRoot =
+                { Lookup =
+                    [(Utilities.hash2 SyntaxHintNode.FuncApp 0,
+                      { Edges = expectedEdges; MatchedHint = [] })] |> toDictionary
+                  AnyMatch = [] }
 
-                let mergedHint = MergeSyntaxTrees.mergeHints [hint; hint2]
+            let mergedHint = MergeSyntaxTrees.mergeHints [hint; hint2]
 
-                Assert.AreEqual(expectedRoot, mergedHint)
-            | _ -> Assert.Fail()
+            Assert.AreEqual(expectedRoot, mergedHint)
+        | _ -> Assert.Fail()
 
     [<Test>]
     member __.``Merge no hints gives no merged lists``() =

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -250,7 +250,7 @@ match args.AstNode with
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``No error for exceptional tuple indentation``() =
+    member this.``No error for exceptional tuple pattern indentation``() =
         this.Parse """
     let (|Cons|_|) pattern =
         match pattern with
@@ -264,6 +264,15 @@ match args.AstNode with
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
+    member this.``No error for exceptional record pattern indentation``() =
+        this.Parse """
+        match x with
+        | X { y = y
+              z = z } -> ()"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``No error for multi-line reference cell assignment``() =
         this.Parse """
         do pstringelemImpl :=
@@ -272,13 +281,3 @@ match args.AstNode with
                   skipChar '\\' >>. pnewline >>. many spaces >>. pstringelem ]"""
 
         Assert.IsTrue(this.NoErrorsExist)
-
-    [<Test>]
-    member this.``No error for this``() =
-         this.Parse """
-    type Context =
-        { IndentationRuleContext : Map<int,bool*int>
-          NoTabCharactersRuleContext : (string * Range.range) list }
-"""
-
-         Assert.IsTrue(this.NoErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/Indentation.fs
@@ -248,3 +248,37 @@ match args.AstNode with
     Array.empty"""
 
         Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for exceptional tuple indentation``() =
+        this.Parse """
+    let (|Cons|_|) pattern =
+        match pattern with
+        | SynPat.LongIdent(LongIdentWithDots([identifier], _),
+                           _, _,
+                           Pats([SynPat.Tuple(_, [lhs; rhs], _)]), _, _)
+                when identifier.idText = "op_ColonColon" ->
+            Some(lhs, rhs)
+        | _ -> None"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for multi-line reference cell assignment``() =
+        this.Parse """
+        do pstringelemImpl :=
+            choice
+                [ attempt pstringchar
+                  skipChar '\\' >>. pnewline >>. many spaces >>. pstringelem ]"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``No error for this``() =
+         this.Parse """
+    type Context =
+        { IndentationRuleContext : Map<int,bool*int>
+          NoTabCharactersRuleContext : (string * Range.range) list }
+"""
+
+         Assert.IsTrue(this.NoErrorsExist)


### PR DESCRIPTION
Updates the lint tool to 0.14.2 and fixes some remaining issues with the indentation rules:
- Handle reference cell assignment operator as a normal assignment
- Handles exceptional indentation within patterns