### PR TITLE
Check record fields in TypedItemSpacing rule

### DIFF
--- a/src/FSharpLint.Core/Framework/Ast.fs
+++ b/src/FSharpLint.Core/Framework/Ast.fs
@@ -420,6 +420,13 @@ module Ast =
         | SynTypeDefnRepr.Exception(exceptionRepr) ->
             add <| exceptionRepresentationNode exceptionRepr
 
+    let inline private unionCaseChildren node add =
+        match node with
+        | SynUnionCase.UnionCase(caseType=(UnionCaseFields fields)) ->
+            fields |> List.revIter (fieldNode >> add)
+        | SynUnionCase.UnionCase(caseType=(UnionCaseFullType (fullType, _))) ->
+            add (typeNode fullType)
+
     /// Extracts the child nodes to be visited from a given node.
     let traverseNode node add =
         match node with
@@ -456,9 +463,9 @@ module Ast =
         | File(ParsedInput.ImplFile(ParsedImplFileInput(_, _, _, _, _, moduleOrNamespaces, _))) ->
             moduleOrNamespaces |> List.revIter (moduleOrNamespaceNode >> add)
 
+        | UnionCase(x) -> unionCaseChildren x add
         | File(ParsedInput.SigFile(_))
         | ComponentInfo(_)
         | EnumCase(_)
-        | UnionCase(_)
         | Identifier(_)
         | TypeParameter(_) -> ()

--- a/src/FSharpLint.Core/Rules/Formatting/TypedItemSpacing.fs
+++ b/src/FSharpLint.Core/Rules/Formatting/TypedItemSpacing.fs
@@ -73,6 +73,8 @@ let runner (config:Config) (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Pattern (SynPat.Typed (range=range))
     | AstNode.Field (SynField.Field (range=range)) ->
+        // NOTE: This currently does not work for fields in union cases, since the range on union case fields is incorrect,
+        // only including the type and not the field name. (https://github.com/dotnet/fsharp/issues/9279)
         checkRange config args range |> Option.toArray
     | _ -> [||]
 

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
@@ -42,10 +42,10 @@ type TestFormattingTypedItemSpaceAfter() =
         this.Parse "type X = { x : int }"
         Assert.IsTrue(this.ErrorExistsAt(1, 11))
 
-    [<Test>]
+    [<Test; Ignore("Test is not passing because UnionCase's field range is incorrect")>]
     member this.``Error for named tuple with spaces around colon``() =
         this.Parse "type X = X of x : int"
-        Assert.IsTrue(this.ErrorExistsAt(1, 11))
+        Assert.IsTrue(this.ErrorExistsAt(1, 13))
 
     [<Test>]
     member this.``Quickfix for typed pattern with spaces around colon``() =

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
@@ -43,6 +43,11 @@ type TestFormattingTypedItemSpaceAfter() =
         Assert.IsTrue(this.ErrorExistsAt(1, 11))
 
     [<Test>]
+    member this.``Error for named tuple with spaces around colon``() =
+        this.Parse "type X = X of x : int"
+        Assert.IsTrue(this.ErrorExistsAt(1, 11))
+
+    [<Test>]
     member this.``Quickfix for typed pattern with spaces around colon``() =
         let source = "let (x : int) = 1"
         let expected = "let (x: int) = 1"

--- a/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Formatting/TypedItemSpacing.fs
@@ -7,7 +7,7 @@ open FSharpLint.Rules.TypedItemSpacing
 [<TestFixture>]
 type TestFormattingTypedItemSpaceAfter() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(TypedItemSpacing.rule { Config.TypedItemStyle = TypedItemStyle.SpaceAfter })
-    
+
     [<Test>]
     member this.``No error for typed pattern with space after colon``() =
         let source = "let (x: int) = 1"
@@ -15,25 +15,35 @@ type TestFormattingTypedItemSpaceAfter() =
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``Error for typed pattern with no spaces around colon``() = 
+    member this.``Error for typed pattern with no spaces around colon``() =
         let source = "let (x:int) = 1"
         this.Parse source
         Assert.IsTrue(this.ErrorExistsAt(1, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with no spaces around colon``() = 
+    member this.``No error for record field with spaces around colon``() =
+        this.Parse "type X = { x : int }"
+        Assert.IsTrue(this.ErrorExistsAt(1, 11))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with no spaces around colon``() =
         let source = "let (x:int) = 1"
         let expected = "let (x: int) = 1"
         this.Parse source
         Assert.AreEqual(expected, this.ApplyQuickFix source)
 
     [<Test>]
-    member this.``Error for typed pattern with spaces around colon``() = 
+    member this.``Error for typed pattern with spaces around colon``() =
         this.Parse "let (x : int) = 1"
         Assert.IsTrue(this.ErrorExistsAt(1, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with spaces around colon``() = 
+    member this.``Error for record field with spaces around colon``() =
+        this.Parse "type X = { x : int }"
+        Assert.IsTrue(this.ErrorExistsAt(1, 11))
+
+    [<Test>]
+    member this.``Quickfix for typed pattern with spaces around colon``() =
         let source = "let (x : int) = 1"
         let expected = "let (x: int) = 1"
         this.Parse source
@@ -44,7 +54,7 @@ type TestFormattingTypedItemSpacesAround() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(TypedItemSpacing.rule { Config.TypedItemStyle = TypedItemStyle.SpacesAround })
 
     [<Test>]
-    member this.``No error for typed pattern with spaces around colon``() = 
+    member this.``No error for typed pattern with spaces around colon``() =
         this.Parse("""
 module Program
 
@@ -53,7 +63,7 @@ let (x : int) = 1""")
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``Error for typed pattern with no spaces around colon``() = 
+    member this.``Error for typed pattern with no spaces around colon``() =
         this.Parse("""
 module Program
 
@@ -62,7 +72,7 @@ let (x:int) = 1""")
         Assert.IsTrue(this.ErrorExistsAt(4, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with spaces around colon``() = 
+    member this.``Quickfix for typed pattern with spaces around colon``() =
         let source = """
 module Program
 
@@ -78,7 +88,7 @@ let (x : int) = 1"""
         Assert.AreEqual(expected, this.ApplyQuickFix source)
 
     [<Test>]
-    member this.``Error for typed pattern with space after colon``() = 
+    member this.``Error for typed pattern with space after colon``() =
         this.Parse("""
 module Program
 
@@ -87,7 +97,7 @@ let (x: int) = 1""")
         Assert.IsTrue(this.ErrorExistsAt(4, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with space after colon``() = 
+    member this.``Quickfix for typed pattern with space after colon``() =
         let source = """
 module Program
 
@@ -101,13 +111,13 @@ let (x : int) = 1"""
 
         this.Parse source
         Assert.AreEqual(expected, this.ApplyQuickFix source)
-              
+
 [<TestFixture>]
 type TestFormattingTypedItemNoSpaces() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(TypedItemSpacing.rule { Config.TypedItemStyle = TypedItemStyle.NoSpaces })
 
     [<Test>]
-    member this.``No error for typed pattern with no spaces around colon``() = 
+    member this.``No error for typed pattern with no spaces around colon``() =
         this.Parse("""
 module Program
 
@@ -116,7 +126,7 @@ let (x:int) = 1""")
         Assert.IsTrue(this.NoErrorsExist)
 
     [<Test>]
-    member this.``Error for typed pattern with spaces around colon``() = 
+    member this.``Error for typed pattern with spaces around colon``() =
         this.Parse("""
 module Program
 
@@ -125,7 +135,7 @@ let (x : int) = 1""")
         Assert.IsTrue(this.ErrorExistsAt(4, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with spaces around colon``() = 
+    member this.``Quickfix for typed pattern with spaces around colon``() =
         let source = """
 module Program
 
@@ -141,7 +151,7 @@ let (x:int) = 1"""
         Assert.AreEqual(expected, this.ApplyQuickFix source)
 
     [<Test>]
-    member this.``Error for typed pattern with space after colon``() = 
+    member this.``Error for typed pattern with space after colon``() =
         this.Parse("""
 module Program
 
@@ -150,7 +160,7 @@ let (x: int) = 1""")
         Assert.IsTrue(this.ErrorExistsAt(4, 5))
 
     [<Test>]
-    member this.``Quickfix for typed pattern with space after colon``() = 
+    member this.``Quickfix for typed pattern with space after colon``() =
         let source = """
 module Program
 


### PR DESCRIPTION
Updates the TypedItemSpacing to check record fields as well. We should also check the types in union case fields, but there seems to be a bug in the parser where the range for the union case fields only includes the type, not the field name.