### PR TITLE
Load fsharplint.json for Default config param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix bugs in Indentation rule
-- Check record fields in TypedItemSpacing rule
+
+## [0.16.2] - 2020-06-10
+- Load config from `fsharplint.json` by default.
 
 ## [0.16.1] - 2020-06-10
 - Fix RecordFieldNames rule incorrectly checking Union Case fields

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -322,6 +322,8 @@ module Lint =
     type ConfigurationParam =
         | Configuration of Configuration
         | FromFile of configPath:string
+        /// Tries to load the config from file `fsharplint.json`.
+        /// If this file doesn't exist or is invalid, falls back to the default configuration.
         | Default
 
     /// Optional parameters that can be provided to the linter.
@@ -368,7 +370,14 @@ module Lint =
                 |> Ok
             with
             | ex -> Error (string ex)
-        | Default -> Ok Configuration.defaultConfiguration
+        | Default ->
+            try
+                Configuration.loadConfig "./fsharplint.json"
+                |> Ok
+            with
+            | ex ->
+                // TODO: log default config load error
+                Ok Configuration.defaultConfiguration
 
     /// Lints an entire F# project by retrieving the files from a given
     /// path to the `.fsproj` file.

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -39,6 +39,8 @@ module Lint =
     type ConfigurationParam =
         | Configuration of Configuration
         | FromFile of configPath:string
+        /// Tries to load the config from file `fsharplint.json`.
+        /// If this file doesn't exist or is invalid, falls back to the default configuration.
         | Default
 
     /// Optional parameters that can be provided to the linter.

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -74,14 +74,30 @@ module TestApi =
 
         [<Test>]
         member __.``Lint multi-targeted project``() =
-            let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject" </> "FSharpLint.FunctionalTest.TestedProject.MultiTarget"
-            let projectFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.MultiTarget.fsproj"
+            let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject" </> "FSharpLint.FunctionalTest.TestedProject.NetCore"
+            let projectFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.NetCore.fsproj"
 
             let result = lintProject OptionalLintParameters.Default projectFile
 
             match result with
             | LintResult.Success warnings ->
                 Assert.AreEqual(9, warnings.Length)
+            | LintResult.Failure err ->
+                Assert.True(false, string err)
+
+        [<Test>]
+        member __.``Lint project with default config tries to load `fsharplint.json``() =
+            let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject" </> "FSharpLint.FunctionalTest.TestedProject.NetCore"
+            let projectFile = projectPath </> "FSharpLint.FunctionalTest.TestedProject.NetCore.fsproj"
+            let tempConfigFile = TestContext.CurrentContext.TestDirectory </> "fsharplint.json"
+            File.WriteAllText (tempConfigFile, """{ "ignoreFiles": ["*"] }""")
+
+            let result = lintProject OptionalLintParameters.Default projectFile
+            File.Delete tempConfigFile
+
+            match result with
+            | LintResult.Success warnings ->
+                Assert.AreEqual(0, warnings.Length)
             | LintResult.Failure err ->
                 Assert.True(false, string err)
 


### PR DESCRIPTION
Updates the `Default` setting for the configuration param to try to load the config from `fsharplint.json` before falling back to the default config.