### PR TITLE
Use PackageLicenseExpression in paket pack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ in order to craft an excellent pull request:
 
    ```bash
    dotnet tool restore
-   dotnet tool build
+   dotnet fake build
    ```
 
 6. Push your topic branch up to your fork:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FSharpLint ![GitHub Actions Build Status](https://github.com/fsprojects/FSharpLint/workflows/.NET%20Core%203.1/badge.svg)]
+# FSharpLint ![GitHub Actions Build Status](https://github.com/fsprojects/FSharpLint/workflows/.NET%20Core%203.1/badge.svg)
 
 FSharpLint is a style checking tool for F#. It points out locations where a set of rules on how F# is to be styled have been broken.
 The tool is configurable via JSON and can be run from a console app, or as an MSBuild task. It also provides an interface to easily integrate the tool into other software.

--- a/build.fsx
+++ b/build.fsx
@@ -108,7 +108,7 @@ Target.create "Pack" (fun _ ->
         ("PackageProjectUrl", gitUrl)
         ("RepositoryType", "git")
         ("RepositoryUrl", gitUrl)
-        ("PackageLicenseUrl", gitUrl + "/LICENSE")
+        ("PackageLicenseExpression", "MIT")
         ("PackageReleaseNotes", packageReleaseNotes)
     ]
 


### PR DESCRIPTION
PackageLicenseUrl is deprecated in nuget, use PackageLicenseExpression instead.