### PR TITLE
Fix off by one error

### DIFF
--- a/src/FSharpLint.Core/Rules/Typography/TrailingNewLineInFile.fs
+++ b/src/FSharpLint.Core/Rules/Typography/TrailingNewLineInFile.fs
@@ -8,8 +8,7 @@ open FSharp.Compiler.Range
 
 let checkTrailingNewLineInFile (args:LineRuleParams) =
     if args.IsLastLine && args.FileContent.EndsWith("\n") then
-        let numberOfLinesIncludingTrailingNewLine = args.LineNumber + 1
-        let pos = mkPos numberOfLinesIncludingTrailingNewLine 0
+        let pos = mkPos args.LineNumber 0
         { Range = mkRange "" pos pos
           Message = Resources.GetString("RulesTypographyTrailingLineError")
           SuggestedFix = None

--- a/tests/FSharpLint.Core.Tests/Rules/Typography/TrailingNewLineInFile.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Typography/TrailingNewLineInFile.fs
@@ -11,4 +11,4 @@ type TestTypographyTrailingNewLineInFile() =
     member this.NewLineOnEndOfFile() =
         this.Parse ("let dog = 9" + System.Environment.NewLine)
 
-        Assert.IsTrue(this.ErrorExistsAt(2, 0))
+        Assert.IsTrue(this.ErrorExistsAt(1, 0))


### PR DESCRIPTION
Exception occurs in line 90 of Rules.fs when TrailingNewLineInFile (FL0063) is set to true. Adjust the position of the error to fix the
issue.

Conceptually we tend to think of `\n` as starting a newline because most editors will display an empty line at the end in the presence of a trailing `\n`. In reality, `\n` simply separates lines and the next line does not exist until we add text to it. You can actually observe this behavior in vim which doesn't display an empty line but can be configured to show the trailing `\n`.