### PR TITLE
Don't complain about naming of extern functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.2] - 2021-07-05
 
+- Fix for extern function naming #487
 - Doc update - configuration file info.
 
 ## [0.19.1] - 2021-06-23

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -243,6 +243,8 @@ let isAttribute name (attributes:SynAttributes) =
 
 let isLiteral = isAttribute "Literal"
 
+let isExtern = isAttribute "DllImport"
+
 let isMeasureType = isAttribute "Measure"
 
 let isNotUnionCase (checkFile:FSharpCheckFileResults) (ident:Ident) =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -36,8 +36,8 @@ let private getIdentifiers (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Expression(SynExpr.ForEach(_, _, true, pattern, _, _, _)) ->
         getPatternIdents false (getValueOrFunctionIdents args.CheckInfo) false pattern
-    | AstNode.Binding(SynBinding(access, _, _, _, attributes, _, valData, pattern, _, _, _, _)) ->
-        if not (isLiteral attributes) then
+    | AstNode.Binding(SynBinding(_, _, _, _, attributes, _, valData, pattern, _, _, _, _)) ->
+        if not (isLiteral attributes || isExtern attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
                 let isPublic = isPublic args.SyntaxArray args.NodeIndex

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -22,6 +22,22 @@ module Program
     let (Cat, _) = 1, 0"""
 
         this.AssertNoWarnings()
+        
+    /// Extern functions typically match the counterpart from the external library 
+    /// and as such often won't follow F#'s conventions.
+    [<Test>]
+    member this.``extern function definition should not trigger naming warnings``() =
+        this.Parse """
+module Program
+        
+open System
+open System.Runtime.InteropServices
+
+[<DllImport(@"python37", EntryPoint = "PyThreadState_SetAsyncExc", CallingConvention = CallingConvention.Cdecl)>]
+extern int PyThreadState_SetAsyncExcLLP64(uint id, IntPtr exc)
+    """
+        
+        this.AssertNoWarnings()
 
     [<Test>]
     member this.PublicTupleIsCamelCase() =


### PR DESCRIPTION
Surprisingly there's no clear `extern` attribute to check on the untyped AST. 

The fix doesn't feel ideal as it's checking for the `DllImport` attribute, however this attribute will always be there and the check is no different to what we're doing for literals today. Might be worth re-checking the situation on using the typed tree which we do in some places, if we could make that more widespread we can have more exact checks for cases like these