### PR TITLE
Generic types rule nits

### DIFF
--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -202,7 +202,7 @@
             "underscores": "None"
         }
     },
-	  "genericTypesNames": {
+    "genericTypesNames": {
         "enabled": true,
         "config": {
             "naming": "PascalCase",  


### PR DESCRIPTION
* fsharplint.json: replace tab char with 2 spaces, for consistency
* GenericTypesNames: simplify rule implementation