### PR TITLE
Upgrade fake-cli from 5.20.4-alpha.1642 to 5.20.4

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "5.20.4-alpha.1642",
+      "version": "5.20.4",
       "commands": [
         "fake"
       ]


### PR DESCRIPTION
Not only 5.20.4 seems to be stable (and last version)
instead of an alpha; also, the build sometimes failed
with this error which could possibly be fixed in the
new version:

```
Run dotnet fake build -t Test
Extracted Paket.Restore.targets to: /home/runner/work/FSharpLint/FSharpLint/.paket/Paket.Restore.targets (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)
Starting full restore process.
Downloading Fake.Core.Xml 5.20.4 (Build)
Downloading BlackFox.VsWhere 1.1 (Build)
<snip />
Download of System.Text.Encoding.Extensions 4.3 (Docs) done in 124 milliseconds. (15754 kbit/s, 0 MB)
Download of Microsoft.Build.Tasks.Core 16.10 (Docs) done in 19 milliseconds. (636826 kbit/s, 1 MB)
Performance:
 - Cli parsing: 273 milliseconds
 - Packages: 8 seconds
   - Disk IO: 2 seconds
   - Average Download Time: 43 milliseconds
   - Number of downloads: 113
   - Average Request Time: 42 milliseconds
   - Number of Requests: 119
 - Script analyzing: 213 milliseconds
 - Runtime: 8 seconds
There was a problem while setting up the environment:
-> Start of process ln failed.
-> InvalidOperationException: Cannot process request because the process (2920) has exited.
Hint: If you just upgraded the fake-runner you can try to remove the .fake directory and try again.
Error: Process completed with exit code 1.
```