### PR TITLE
Enable running tool on .Net 6

### DIFF
--- a/src/FSharpLint.Console/FSharpLint.Console.fsproj
+++ b/src/FSharpLint.Console/FSharpLint.Console.fsproj
@@ -12,6 +12,7 @@
     <AssemblyName>dotnet-fsharplint</AssemblyName>
     <RootNamespace>FSharpLint.Console</RootNamespace>
     <IsPackable>true</IsPackable>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This will fix issue #519 

This adds a rollForward "Major" to the console application project file, enabling the app to run on Net,6 

This was tested by running the tool from inside a container based on the MSFT for net. 6, after copying the output from the project into the image.  Without the fix, this method would fail. 

