### PR TITLE
Add 2 new rules NestedFunctionNames and UnnestedFunctionNames

### DIFF
--- a/docs/content/how-tos/rule-configuration.md
+++ b/docs/content/how-tos/rule-configuration.md
@@ -115,3 +115,5 @@ The following rules can be specified for linting.
 - [FailwithBadUsage (FL0072)](rules/FL0072.html)
 - [FavourReRaise (FL0073)](rules/FL0073.html)
 - [FavourConsistentThis (FL0074)](rules/FL0074.html)
+- [UnnestedFunctionNames (FL0075)](rules/FL0075.html)
+- [NestedFunctionNames (FL0076)](rules/FL0076.html)

--- a/docs/content/how-tos/rules/FL0075.md
+++ b/docs/content/how-tos/rules/FL0075.md
@@ -1,0 +1,33 @@
+---
+title: FL0075
+category: how-to
+hide_menu: true
+---
+
+# UnnestedFunctionNames (FL0075)
+
+*Introduced in `0.21.1`*
+
+## Cause
+
+Unnested function naming does not match the specified config.
+
+## Rationale
+
+Consistency aides readability.
+
+## How To Fix
+
+Update the unnested function names to be consistent with the rules you have specified
+
+## Rule Settings
+
+    {
+        "unnestedFunctionNames": {
+            "enabled": false,
+            "config": {
+                "naming": "PascalCase",
+                "underscores": "None"
+            }
+        }
+    }

--- a/docs/content/how-tos/rules/FL0076.md
+++ b/docs/content/how-tos/rules/FL0076.md
@@ -1,0 +1,33 @@
+---
+title: FL0076
+category: how-to
+hide_menu: true
+---
+
+# NestedFunctionNames (FL0076)
+
+*Introduced in `0.21.1`*
+
+## Cause
+
+Nested function naming does not match the specified config.
+
+## Rationale
+
+Consistency aides readability.
+
+## How To Fix
+
+Update the Nested function names to be consistent with the rules you have specified
+
+## Rule Settings
+
+    {
+        "NestedFunctionNames": {
+        "enabled": false,
+            "config": {
+                "naming": "CamelCase",
+                "underscores": "None"
+            }
+        }
+    }

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -84,6 +84,8 @@
     <Compile Include="Rules\Conventions\Naming\LiteralNames.fs" />
     <Compile Include="Rules\Conventions\Naming\NamespaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MemberNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\UnnestedFunctionNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\NestedFunctionNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ParameterNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MeasureTypeNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ActivePatternNames.fs" />

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -361,3 +361,22 @@ let rec identFromSimplePat = function
     | SynSimplePat.Id(ident, _, _, _, _, _) -> Some(ident)
     | SynSimplePat.Typed(p, _, _) -> identFromSimplePat p
     | SynSimplePat.Attrib(_) -> None
+
+let rec isNested args nodeIndex =
+    let parent = args.SyntaxArray.[nodeIndex].ParentIndex
+    let actual = args.SyntaxArray.[parent].Actual
+
+    match actual with
+    | AstNode.Expression (SynExpr.LetOrUse (_, _, _, _, _)) -> true
+    | _ -> false
+
+let getFunctionIdents _ =
+    function
+    | SynPat.LongIdent (longIdent, _, _, pats, _, _) ->
+        match pats with
+        | SynArgPats.Pats _ ->
+            match List.tryLast longIdent.Lid with
+            | Some ident -> (ident, ident.idText, None) |> Array.singleton
+            | None -> Array.empty
+        | _ -> Array.empty
+    | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -1,0 +1,25 @@
+module FSharpLint.Rules.NestedFunctionNames
+
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.AstInfo
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules.Helper.Naming
+
+let private getIdentifiers (args: AstNodeRuleParams) =
+    match args.AstNode with
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
+        if isNested args args.NodeIndex then
+            getPatternIdents Accessibility.Public getFunctionIdents true pattern
+        else
+            Array.empty
+    | _ -> Array.empty
+
+let rule config =
+    { Name = "NestedFunctionNames"
+      Identifier = Identifiers.NestedFunctionNames
+      RuleConfig =
+        { NamingRuleConfig.Config = config
+          GetIdentifiersToCheck = getIdentifiers } }
+    |> toAstNodeRule
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -1,0 +1,25 @@
+module FSharpLint.Rules.UnnestedFunctionNames
+
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.AstInfo
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules.Helper.Naming
+
+let private getIdentifiers (args: AstNodeRuleParams) =
+    match args.AstNode with
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
+        if isNested args args.NodeIndex then
+            Array.empty
+        else
+            getPatternIdents Accessibility.Public getFunctionIdents true pattern
+    | _ -> Array.empty
+
+let rule config =
+    { Name = "UnnestedFunctionNames"
+      Identifier = Identifiers.UnnestedFunctionNames
+      RuleConfig =
+        { NamingRuleConfig.Config = config
+          GetIdentifiersToCheck = getIdentifiers } }
+    |> toAstNodeRule
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -79,3 +79,5 @@ let CyclomaticComplexity = identifier 71
 let FailwithBadUsage = identifier 72
 let FavourReRaise = identifier 73
 let FavourConsistentThis = identifier 74
+let UnnestedFunctionNames = identifier 75
+let NestedFunctionNames = identifier 76

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -236,6 +236,20 @@
             "underscores": "AllowPrefix"
         }
     },
+    "unnestedFunctionNames": {
+        "enabled": false,
+        "config": {
+            "naming": "PascalCase",
+            "underscores": "None"
+        }
+    },
+    "nestedFunctionNames": {
+        "enabled": false,
+        "config": {
+            "naming": "CamelCase",
+            "underscores": "None"
+        }
+    },
     "maxNumberOfItemsInTuple": {
         "enabled": false,
         "config": {

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -48,6 +48,8 @@
     <Compile Include="Rules\Conventions\Naming\LiteralNames.fs" />
     <Compile Include="Rules\Conventions\Naming\NamespaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MemberNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\UnnestedFunctionNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\NestedFunctionNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ParameterNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MeasureTypeNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ActivePatternNames.fs" />

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -1,0 +1,80 @@
+module FSharpLint.Core.Tests.Rules.Conventions.NestedFunctionNames
+
+open NUnit.Framework
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules
+
+let config =
+    { NamingConfig.Naming = Some NamingCase.CamelCase
+      Underscores = Some NamingUnderscores.None
+      Prefix = None
+      Suffix = None }
+
+[<TestFixture>]
+type TestConventionsNestedFunctionNames() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(NestedFunctionNames.rule config)
+
+    [<Test>]
+    member this.UnnestedFunctionNameInPascalCaseMustBeIgnored() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let nestedFunction arg1 =
+            arg1 + 1
+
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+let CylinderVolume radius length =
+    let NestedFunction arg1 =
+        arg1 + 1
+
+    let pi = 3.14159
+    length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 8))
+
+    [<Test>]
+    member this.NestedFunctionNameInTypeIsPascalCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.CylinderVolume length radius =
+        let NestedFunction arg1 =
+            arg1 + 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(5, 12))
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let CylinderVolume2() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -1,0 +1,174 @@
+module FSharpLint.Core.Tests.Rules.Conventions.UnnestedFunctionNames
+
+open NUnit.Framework
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules
+
+let config =
+    { NamingConfig.Naming = Some NamingCase.PascalCase
+      Underscores = Some NamingUnderscores.None
+      Prefix = None
+      Suffix = None }
+
+[<TestFixture>]
+type TestConventionsUnnestedFunctionNames() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(UnnestedFunctionNames.rule config)
+
+    [<Test>]
+    member this.FunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.FunctionNameHasUnderscore() =
+        this.Parse """
+module Program =
+    let Cylinder_Volume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let cylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameWithNoArgsIsCamelCase() =
+        this.Parse """
+module Program =
+    let cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameWithNoArgsIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.ValueNameWithNoArgsAndNoParenthesisIsCamelCase() =
+        this.Parse """
+module Program
+    let cylinderVolume =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.PrivateFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let private cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 16))
+
+    [<Test>]
+    member this.PublicFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let public cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 15))
+
+    [<Test>]
+    member this.FunctionNameInTypeIsCamelCase() =
+        this.Parse """
+type MyClass(initX:int) =
+   let x = initX
+   member this.method() = printf "x=%i" x"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 15))
+
+    [<Test>]
+    member this.FunctionNameInRecordIsCamelCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.cylinderVolume length radius =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 16))
+
+    [<Test>]
+    member this.NestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let nestedFunction arg1 =
+            arg1 + 1
+
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameInTypeIsCamelCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.CylinderVolume length radius =
+        let nestedFunction arg1 =
+            arg1 + 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let CylinderVolume2() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let raius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let cylinderVolume2() =
+        let raius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(8, 8))


### PR DESCRIPTION
These rules allow configuring naming conventions for nested and unnested function names.