### PR TITLE
FailwithBadUsage: cover more scenarios 

### DIFF
--- a/docs/content/how-tos/rules/FL0072.md
+++ b/docs/content/how-tos/rules/FL0072.md
@@ -10,7 +10,7 @@ hide_menu: true
 
 ## Cause
 
-Rule to detect bad usage of failwith.
+Using failwith in improper places or with dubious parameters.
 
 ## Rationale
 

--- a/docs/content/how-tos/rules/FL0073.md
+++ b/docs/content/how-tos/rules/FL0073.md
@@ -4,7 +4,7 @@ category: how-to
 hide_menu: true
 ---
 
-# FailwithBadUsage (FL0073)
+# FavourReRaise (FL0073)
 
 *Introduced in `0.21.0`*
 

--- a/src/FSharpLint.Core/Rules/Conventions/RaiseWithTooManyArguments/FailwithBadUsage.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/RaiseWithTooManyArguments/FailwithBadUsage.fs
@@ -38,11 +38,11 @@ let private runner (args: AstNodeRuleParams) =
 
         let message =
             match badUsageType with
-            | EmptyMessage -> "Consider using non-empty error messages with failwith"
-            | DuplicateMessage -> "Consider using unique error messages with failwith"
+            | EmptyMessage -> "consider using a non-empty error message as parameter"
+            | DuplicateMessage -> "consider using unique error messages as parameters"
             | SwallowedException ->
-                "failwith must not swallow exception details with it, rather use raise passing the current exception as innerException (2nd parameter of Exception constructor)"
-            | NullMessage -> "Consider using non-null error messages with failwith"
+                "rather use `raise` passing the current exception as innerException (2nd parameter of Exception constructor), otherwise using `failwith` the exception details will be swallowed"
+            | NullMessage -> "consider using a non-null error messages as parameter"
         let error =
             { Range = range
               Message = String.Format(Resources.GetString "RulesFailwithBadUsage", message)

--- a/src/FSharpLint.Core/Rules/Conventions/RaiseWithTooManyArguments/FailwithBadUsage.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/RaiseWithTooManyArguments/FailwithBadUsage.fs
@@ -14,6 +14,7 @@ type private BadUsageType =
     | EmptyMessage
     | DuplicateMessage
     | SwallowedException
+    | NullMessage
 
 let private runner (args: AstNodeRuleParams) =
     let generateError
@@ -41,7 +42,7 @@ let private runner (args: AstNodeRuleParams) =
             | DuplicateMessage -> "Consider using unique error messages with failwith"
             | SwallowedException ->
                 "failwith must not swallow exception details with it, rather use raise passing the current exception as innerException (2nd parameter of Exception constructor)"
-
+            | NullMessage -> "Consider using non-null error messages with failwith"
         let error =
             { Range = range
               Message = String.Format(Resources.GetString "RulesFailwithBadUsage", message)
@@ -72,6 +73,7 @@ let private runner (args: AstNodeRuleParams) =
                         Array.empty
             | SynExpr.LongIdent (_, LongIdentWithDots (id, _), _, _) when
                 (ExpressionUtilities.longIdentToString id) = "String.Empty"
+                || (ExpressionUtilities.longIdentToString id) = "System.String.Empty"
                 ->
                 generateError
                     failwithId.idText
@@ -79,6 +81,8 @@ let private runner (args: AstNodeRuleParams) =
                     range
                     (BadUsageType.EmptyMessage)
                     (None)
+            | SynExpr.Null range -> 
+                generateError failwithId.idText "null" range BadUsageType.NullMessage maybeIdentifier
             | _ -> Array.empty
         | SynExpr.TryWith (_, _, clauseList, _expression, _range, _, _) ->
             clauseList
@@ -89,7 +93,7 @@ let private runner (args: AstNodeRuleParams) =
                     match pat with
                     | SynPat.Named (_, id, _, _, _) -> checkExpr app (Some id.idText)
                     | _ -> checkExpr app None)
-        | _ -> Array.empty
+                | _ -> Array.empty
         | _ -> Array.empty
 
     match args.AstNode with

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FailwithBadUsage.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FailwithBadUsage.fs
@@ -116,3 +116,21 @@ let foo () =
 
         Assert.IsTrue this.ErrorsExist
         Assert.IsTrue(this.ErrorExistsAt(3, 4))
+
+    [<Test>]
+    member this.FailwithfWithNullArgument() =
+        this.Parse """
+let foo () =
+    failwithf null"""
+
+        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue(this.ErrorExistsAt(3, 14))
+
+    [<Test>]
+    member this.FailwithfWithFullNameModuleEmptyMessage() =
+        this.Parse """
+let bar () =
+    failwithf System.String.Empty"""
+
+        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue(this.ErrorExistsAt(3, 4))


### PR DESCRIPTION
* The new unit tests are:
  1) FailwithfWithNullArgument
  2) FailwithfWithFullNameModuleEmptyMessage