### PR TITLE
Add 2 new rules NestedFunctionNames and UnnestedFunctionNames

### DIFF
--- a/docs/content/how-tos/rule-configuration.md
+++ b/docs/content/how-tos/rule-configuration.md
@@ -120,3 +120,5 @@ The following rules can be specified for linting.
 - [AvoidSinglePipeOperator (FL0077)](rules/FL0077.html)
 - [AsyncExceptionWithoutReturn (FL0078)](rules/FL0078.html)
 - [SuggestUseAutoProperty (FL0079)](rules/FL0079.html)
+- [UnnestedFunctionNames (FL0080)](rules/FL0080.html)
+- [NestedFunctionNames (FL0081)](rules/FL0081.html)

--- a/docs/content/how-tos/rules/FL0080.md
+++ b/docs/content/how-tos/rules/FL0080.md
@@ -1,0 +1,33 @@
+---
+title: FL0080
+category: how-to
+hide_menu: true
+---
+
+# UnnestedFunctionNames (FL0080)
+
+*Introduced in `0.21.8`*
+
+## Cause
+
+Unnested function naming does not match the specified config.
+
+## Rationale
+
+Consistency aides readability.
+
+## How To Fix
+
+Update the unnested function names to be consistent with the rules you have specified.
+
+## Rule Settings
+
+    {
+        "UnnestedFunctionNames": {
+            "enabled": false,
+            "config": {
+                "naming": "PascalCase",
+                "underscores": "None"
+            }
+        }
+    }

--- a/docs/content/how-tos/rules/FL0081.md
+++ b/docs/content/how-tos/rules/FL0081.md
@@ -1,0 +1,33 @@
+---
+title: FL0081
+category: how-to
+hide_menu: true
+---
+
+# NestedFunctionNames (FL0081)
+
+*Introduced in `0.21.8`*
+
+## Cause
+
+Nested function naming does not match the specified config.
+
+## Rationale
+
+Consistency aides readability.
+
+## How To Fix
+
+Update the nested function names to be consistent with the rules you have specified.
+
+## Rule Settings
+
+    {
+        "NestedFunctionNames": {
+            "enabled": false,
+            "config": {
+                "naming": "CamelCase",
+                "underscores": "None"
+            }
+        }
+    }

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -88,6 +88,8 @@
     <Compile Include="Rules\Conventions\Naming\LiteralNames.fs" />
     <Compile Include="Rules\Conventions\Naming\NamespaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MemberNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\UnnestedFunctionNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\NestedFunctionNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ParameterNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MeasureTypeNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ActivePatternNames.fs" />

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -377,13 +377,10 @@ let rec isNested args nodeIndex =
     | AstNode.Expression (SynExpr.LetOrUse _) -> true
     | _ -> false
 
-let getFunctionIdents _ =
-    function
-    | SynPat.LongIdent (longIdent, _, _, pats, _, _) ->
-        match pats with
-        | SynArgPats.Pats _ ->
-            match List.tryLast longIdent.Lid with
-            | Some ident -> (ident, ident.idText, None) |> Array.singleton
-            | None -> Array.empty
-        | _ -> Array.empty
+let getFunctionIdents (_accessibility: AccessControlLevel) (pattern: SynPat) =
+    match pattern with
+    | SynPat.LongIdent (longIdent, _, _, SynArgPats.Pats _, _, _) ->
+        match List.tryLast longIdent.Lid with
+        | Some ident -> (ident, ident.idText, None) |> Array.singleton
+        | None -> Array.empty
     | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -365,6 +365,25 @@ let rec getPatternIdents<'T> (accessibility:AccessControlLevel) (getIdents:GetId
     | SynPat.DeprecatedCharRange(_) | SynPat.InstanceMember(_) | SynPat.FromParseError(_) -> Array.empty
 
 let rec identFromSimplePat = function
-    | SynSimplePat.Id(ident, _, _, _, _, _) -> Some(ident)
+    | SynSimplePat.Id(ident, _, _, _, _, _) -> Some ident
     | SynSimplePat.Typed(p, _, _) -> identFromSimplePat p
     | SynSimplePat.Attrib(_) -> None
+
+let rec isNested args nodeIndex =
+    let parent = args.SyntaxArray.[nodeIndex].ParentIndex
+    let actual = args.SyntaxArray.[parent].Actual
+
+    match actual with
+    | AstNode.Expression (SynExpr.LetOrUse _) -> true
+    | _ -> false
+
+let getFunctionIdents _ =
+    function
+    | SynPat.LongIdent (longIdent, _, _, pats, _, _) ->
+        match pats with
+        | SynArgPats.Pats _ ->
+            match List.tryLast longIdent.Lid with
+            | Some ident -> (ident, ident.idText, None) |> Array.singleton
+            | None -> Array.empty
+        | _ -> Array.empty
+    | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -377,7 +377,7 @@ let rec isNested args nodeIndex =
     | AstNode.Expression (SynExpr.LetOrUse _) -> true
     | _ -> false
 
-let getFunctionIdents (_accessibility: AccessControlLevel) (pattern: SynPat) =
+let getFunctionIdents (pattern:SynPat) =
     match pattern with
     | SynPat.LongIdent (longIdent, _, _, SynArgPats.Pats _, _, _) ->
         match List.tryLast longIdent.Lid with

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -10,7 +10,8 @@ let private getIdentifiers (args: AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
         if isNested args args.NodeIndex then
-            getPatternIdents AccessControlLevel.Public getFunctionIdents true pattern
+            let allEncompassingAccessibility = AccessControlLevel.Public
+            getPatternIdents allEncompassingAccessibility (fun _accessibility pat -> getFunctionIdents pat) true pattern
         else
             Array.empty
     | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -1,0 +1,25 @@
+module FSharpLint.Rules.NestedFunctionNames
+
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.AstInfo
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules.Helper.Naming
+
+let private getIdentifiers (args: AstNodeRuleParams) =
+    match args.AstNode with
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
+        if isNested args args.NodeIndex then
+            getPatternIdents AccessControlLevel.Public getFunctionIdents true pattern
+        else
+            Array.empty
+    | _ -> Array.empty
+
+let rule config =
+    { Name = "NestedFunctionNames"
+      Identifier = Identifiers.NestedFunctionNames
+      RuleConfig =
+        { NamingRuleConfig.Config = config
+          GetIdentifiersToCheck = getIdentifiers } }
+    |> toAstNodeRule
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -10,8 +10,8 @@ let private getIdentifiers (args: AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
         if isNested args args.NodeIndex then
-            let allEncompassingAccessibility = AccessControlLevel.Public
-            getPatternIdents allEncompassingAccessibility (fun _accessibility pat -> getFunctionIdents pat) true pattern
+            let maxAccessibility = AccessControlLevel.Public
+            getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
         else
             Array.empty
     | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -12,7 +12,8 @@ let private getIdentifiers (args: AstNodeRuleParams) =
         if isNested args args.NodeIndex then
             Array.empty
         else
-            getPatternIdents AccessControlLevel.Public getFunctionIdents true pattern
+            let allEncompassingAccessibility = AccessControlLevel.Public
+            getPatternIdents allEncompassingAccessibility (fun _accessibility pat -> getFunctionIdents pat) true pattern
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -12,8 +12,8 @@ let private getIdentifiers (args: AstNodeRuleParams) =
         if isNested args args.NodeIndex then
             Array.empty
         else
-            let allEncompassingAccessibility = AccessControlLevel.Public
-            getPatternIdents allEncompassingAccessibility (fun _accessibility pat -> getFunctionIdents pat) true pattern
+            let maxAccessibility = AccessControlLevel.Public
+            getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -1,0 +1,25 @@
+module FSharpLint.Rules.UnnestedFunctionNames
+
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.AstInfo
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules.Helper.Naming
+
+let private getIdentifiers (args: AstNodeRuleParams) =
+    match args.AstNode with
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _)) ->
+        if isNested args args.NodeIndex then
+            Array.empty
+        else
+            getPatternIdents AccessControlLevel.Public getFunctionIdents true pattern
+    | _ -> Array.empty
+
+let rule config =
+    { Name = "UnnestedFunctionNames"
+      Identifier = Identifiers.UnnestedFunctionNames
+      RuleConfig =
+        { NamingRuleConfig.Config = config
+          GetIdentifiersToCheck = getIdentifiers } }
+    |> toAstNodeRule
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -84,3 +84,5 @@ let FavourStaticEmptyFields = identifier 76
 let AvoidSinglePipeOperator = identifier 77
 let AsyncExceptionWithoutReturn = identifier 78
 let SuggestUseAutoProperty = identifier 79
+let UnnestedFunctionNames = identifier 80
+let NestedFunctionNames = identifier 81

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -237,6 +237,20 @@
             "underscores": "AllowPrefix"
         }
     },
+    "unnestedFunctionNames": {
+        "enabled": false,
+        "config": {
+            "naming": "PascalCase",
+            "underscores": "None"
+        }
+    },
+    "nestedFunctionNames": {
+        "enabled": false,
+        "config": {
+            "naming": "CamelCase",
+            "underscores": "None"
+        }
+    },
     "maxNumberOfItemsInTuple": {
         "enabled": false,
         "config": {

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -53,6 +53,8 @@
     <Compile Include="Rules\Conventions\Naming\LiteralNames.fs" />
     <Compile Include="Rules\Conventions\Naming\NamespaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MemberNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\UnnestedFunctionNames.fs" />
+    <Compile Include="Rules\Conventions\Naming\NestedFunctionNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ParameterNames.fs" />
     <Compile Include="Rules\Conventions\Naming\MeasureTypeNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ActivePatternNames.fs" />

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -1,0 +1,102 @@
+module FSharpLint.Core.Tests.Rules.Conventions.NestedFunctionNames
+
+open NUnit.Framework
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules
+
+let config =
+    { NamingConfig.Naming = Some NamingCase.CamelCase
+      Underscores = Some NamingUnderscores.None
+      Prefix = None
+      Suffix = None }
+
+[<TestFixture>]
+type TestConventionsNestedFunctionNames() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(NestedFunctionNames.rule config)
+
+    [<Test>]
+    member this.UnnestedFunctionNameInPascalCaseMustBeIgnored() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let nestedFunction arg1 =
+            arg1 + 1
+
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+let CylinderVolume radius length =
+    let NestedFunction arg1 =
+        arg1 + 1
+
+    let pi = 3.14159
+    length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 8))
+
+    [<Test>]
+    member this.NestedFunctionNameInTypeIsPascalCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.CylinderVolume length radius =
+        let NestedFunction arg1 =
+            arg1 + 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(5, 12))
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let CylinderVolume2() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.PrivateUnnestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let private CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.PrivateUnnestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let private cylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -1,0 +1,185 @@
+module FSharpLint.Core.Tests.Rules.Conventions.UnnestedFunctionNames
+
+open NUnit.Framework
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules
+
+let config =
+    { NamingConfig.Naming = Some NamingCase.PascalCase
+      Underscores = Some NamingUnderscores.None
+      Prefix = None
+      Suffix = None }
+
+[<TestFixture>]
+type TestConventionsUnnestedFunctionNames() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(UnnestedFunctionNames.rule config)
+
+    [<Test>]
+    member this.FunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.FunctionNameHasUnderscore() =
+        this.Parse """
+module Program =
+    let Cylinder_Volume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let cylinderVolume radius length =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameWithNoArgsIsCamelCase() =
+        this.Parse """
+module Program =
+    let cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 8))
+
+    [<Test>]
+    member this.FunctionNameWithNoArgsIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.ValueNameWithNoArgsAndNoParenthesisIsCamelCase() =
+        this.Parse """
+module Program
+    let cylinderVolume =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.PrivateFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let private cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 16))
+
+    [<Test>]
+    member this.PublicFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let public cylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(3, 15))
+
+
+    [<Test>]
+    member this.PrivateFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let private CylinderVolume() =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.FunctionNameInTypeIsCamelCase() =
+        this.Parse """
+type MyClass(initX:int) =
+   let x = initX
+   member this.method() = printf "x=%i" x"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 15))
+
+    [<Test>]
+    member this.FunctionNameInRecordIsCamelCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.cylinderVolume length radius =
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 16))
+
+    [<Test>]
+    member this.NestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume radius length =
+        let nestedFunction arg1 =
+            arg1 + 1
+
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.NestedFunctionNameInTypeIsCamelCase() =
+        this.Parse """
+type Record =
+    { Dog: int }
+    member this.CylinderVolume length radius =
+        let nestedFunction arg1 =
+            arg1 + 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let CylinderVolume2() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        this.AssertNoWarnings()
+
+    [<Test>]
+    member this.UnnestedFunctionNameIsCamelCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius
+
+    let cylinderVolume2() =
+        let radius = 1
+        let pi = 3.14159
+        length * pi * radius * radius"""
+
+        Assert.IsTrue(this.ErrorExistsAt(8, 8))


### PR DESCRIPTION
These rules allow configuring naming conventions for nested and unnested function names.