### PR TITLE
Conventions/Naming: rename Accessibility DU to AccessControlLevel

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/ActivePatternNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/ActivePatternNames.fs
@@ -25,7 +25,7 @@ let private getValueOrFunctionIdents _ pattern =
 let private getIdentifiers (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Expression(SynExpr.ForEach(_, _, true, pattern, _, _, _)) ->
-        getPatternIdents Accessibility.Private getValueOrFunctionIdents false pattern
+        getPatternIdents AccessControlLevel.Private getValueOrFunctionIdents false pattern
     | AstNode.Binding(SynBinding(_, _, _, _, attributes, _, valData, pattern, _, _, _, _)) ->
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/InternalValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/InternalValuesNames.fs
@@ -20,7 +20,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when not (isActivePattern ident) && singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if isPublic = Accessibility.Internal then
+            if isPublic = AccessControlLevel.Internal then
                 (ident, ident.idText, Some checkNotUnionCase)
                 |> Array.singleton
             else

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/MemberNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/MemberNames.fs
@@ -29,7 +29,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes) && not (isImplementingInterface parents) then
             match identifierTypeFromValData valData with
             | Member | Property ->
-                getPatternIdents Accessibility.Private getMemberIdents true pattern
+                getPatternIdents AccessControlLevel.Private getMemberIdents true pattern
             | _ -> Array.empty
         else
             Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
@@ -43,12 +43,12 @@ let private getIdentifiers (args:AstNodeRuleParams) =
                 let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
                 getPatternIdents accessibility (getValueOrFunctionIdents args.CheckInfo) true pattern
             | Member | Property ->
-                getPatternIdents Accessibility.Private getMemberIdents true pattern
+                getPatternIdents AccessControlLevel.Private getMemberIdents true pattern
             | _ -> Array.empty
         else
             Array.empty
     | AstNode.Expression(SynExpr.ForEach(_, _, true, pattern, _, _, _)) ->
-        getPatternIdents Accessibility.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
+        getPatternIdents AccessControlLevel.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
     | _ -> Array.empty
 
 let rule config =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PrivateValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PrivateValuesNames.fs
@@ -20,7 +20,7 @@ let private getValueOrFunctionIdents typeChecker accessibility pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when not (isActivePattern ident) && singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if accessibility = Accessibility.Private then
+            if accessibility = AccessControlLevel.Private then
                 (ident, ident.idText, Some checkNotUnionCase)
                 |> Array.singleton
             else
@@ -31,7 +31,7 @@ let private getValueOrFunctionIdents typeChecker accessibility pattern =
 let private getIdentifiers (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Expression(SynExpr.ForEach(_, _, true, pattern, _, _, _)) ->
-        getPatternIdents Accessibility.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
+        getPatternIdents AccessControlLevel.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
     | AstNode.Binding(SynBinding(access, _, _, _, attributes, _, valData, pattern, _, _, _, _)) ->
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -24,7 +24,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if isPublic = Accessibility.Public && isNotActivePattern ident then
+            if isPublic = AccessControlLevel.Public && isNotActivePattern ident then
                 (ident, ident.idText, Some checkNotUnionCase)
                 |> Array.singleton
             else
@@ -35,7 +35,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
 let private getIdentifiers (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Expression(SynExpr.ForEach(_, _, true, pattern, _, _, _)) ->
-        getPatternIdents Accessibility.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
+        getPatternIdents AccessControlLevel.Private (getValueOrFunctionIdents args.CheckInfo) false pattern
     | AstNode.Binding(SynBinding(_, _, _, _, attributes, _, valData, pattern, _, _, _, _)) ->
         if not (isLiteral attributes || isExtern attributes) then
             match identifierTypeFromValData valData with


### PR DESCRIPTION
Also added comment to `AccessControlLevel` describing relationships between values of this DU.