### PR TITLE
.config/dotnet-tools: remove recursive dependency

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -14,12 +14,6 @@
         "paket"
       ]
     },
-    "dotnet-fsharplint": {
-      "version": "0.16.1",
-      "commands": [
-        "dotnet-fsharplint"
-      ]
-    },
     "fornax": {
       "version": "0.13.1",
       "commands": [


### PR DESCRIPTION
This repo depended on the nuget package of itself, I guess because we used to have some CI step that checked FSharpLint's code against itself. We seem to not have that step anymore, but if we want to revive it, we should do it with version of FSharpLint that is compiled in the CI itself, to not have a recursive dependency on older versions.