### PR TITLE
Rename dotnet-fsharplint to fsharplint-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The [docs](http://fsprojects.github.io/FSharpLint/) contains an overview of the 
 
 Package | Version
 ------- | --------
-[dotnet tool](https://www.nuget.org/packages/dotnet-fsharplint/) | [![NuGet Status](http://img.shields.io/nuget/v/dotnet-fsharplint.svg?style=flat)](https://www.nuget.org/packages/dotnet-fsharplint/)
+[dotnet tool](https://www.nuget.org/packages/fsharplint-tool/) | [![NuGet Status](http://img.shields.io/nuget/v/fsharplint-tool.svg?style=flat)](https://www.nuget.org/packages/fsharplint-tool/)
 [API](https://www.nuget.org/packages/FSharpLint.Core/) | [![NuGet Status](http://img.shields.io/nuget/v/FSharpLint.Core.svg?style=flat)](https://www.nuget.org/packages/FSharpLint.Core/)
 
 ## How to build application

--- a/src/FSharpLint.Console/FSharpLint.Console.fsproj
+++ b/src/FSharpLint.Console/FSharpLint.Console.fsproj
@@ -9,7 +9,7 @@
     <PackageTags>F#;fsharp;lint;FSharpLint;fslint;cli</PackageTags>
     <PackageType>DotNetCliTool</PackageType>
     <PackAsTool>true</PackAsTool>
-    <AssemblyName>dotnet-fsharplint</AssemblyName>
+    <AssemblyName>fsharplint-tool</AssemblyName>
     <RootNamespace>FSharpLint.Console</RootNamespace>
     <IsPackable>true</IsPackable>
     <RollForward>Major</RollForward>

--- a/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
+++ b/tests/FSharpLint.FunctionalTest/TestConsoleApplication.fs
@@ -30,7 +30,7 @@ module Tests =
                 "Release"
             #endif
 
-        let dll = basePath </> "src" </> "FSharpLint.Console" </> "bin" </> binDir </> "net5.0" </> "dotnet-fsharplint.dll"
+        let dll = basePath </> "src" </> "FSharpLint.Console" </> "bin" </> binDir </> "net5.0" </> "fsharplint-tool.dll"
 
         let startInfo = ProcessStartInfo
                                 (FileName = "dotnet",


### PR DESCRIPTION
Given the previous maintainer seems unresponsive, and is the sole owner of the dotnet-fsharplint nuget package, we may need a way around it (his nuget key expired and we can't renew it without him).

(Longer term, it's maybe better to actually take over the old nuget package called "fsharplint", which is also owned by "fsprojects", but let's do that later.)