### PR TITLE
Rename functions and parameters dealing with AccessControlLevel

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/ActivePatternNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/ActivePatternNames.fs
@@ -30,7 +30,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
-                let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
+                let accessibility = getAccessControlLevel args.SyntaxArray args.NodeIndex
                 getPatternIdents accessibility getValueOrFunctionIdents true pattern
             | _ -> Array.empty
         else

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/InternalValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/InternalValuesNames.fs
@@ -6,7 +6,7 @@ open FSharpLint.Framework.AstInfo
 open FSharpLint.Framework.Rules
 open FSharpLint.Rules.Helper.Naming
 
-let private getValueOrFunctionIdents typeChecker isPublic pattern =
+let private getValueOrFunctionIdents typeChecker accessControlLevel pattern =
     let checkNotUnionCase ident = fun () ->
         typeChecker
         |> Option.map (fun checker -> isNotUnionCase checker ident)
@@ -20,7 +20,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when not (isActivePattern ident) && singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if isPublic = AccessControlLevel.Internal then
+            if accessControlLevel = AccessControlLevel.Internal then
                 (ident, ident.idText, Some checkNotUnionCase)
                 |> Array.singleton
             else
@@ -34,7 +34,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
-                let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
+                let accessibility = getAccessControlLevel args.SyntaxArray args.NodeIndex
                 getPatternIdents accessibility (getValueOrFunctionIdents args.CheckInfo) true pattern
             | _ -> Array.empty
         else

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -189,8 +189,8 @@ type AccessControlLevel =
     | Private
     | Internal
 
-let getAccessibility (syntaxArray:AbstractSyntaxArray.Node []) i =
-    let isSynAccessPublic = function
+let getAccessControlLevel (syntaxArray:AbstractSyntaxArray.Node []) i =
+    let resolveAccessControlLevel = function
         | Some(SynAccess.Public) | None -> AccessControlLevel.Public
         | Some(SynAccess.Private) -> AccessControlLevel.Private
         | Some(SynAccess.Internal) -> AccessControlLevel.Internal
@@ -209,7 +209,7 @@ let getAccessibility (syntaxArray:AbstractSyntaxArray.Node []) i =
             | ExceptionRepresentation(SynExceptionDefnRepr.SynExceptionDefnRepr(_, _, _, _, access, _))
             | Pattern(SynPat.Named(_, _, _, access, _))
             | Pattern(SynPat.LongIdent(_, _, _, _, access, _)) ->
-                getAccessibility (isSynAccessPublic access) isPrivateWhenReachedBinding node.ParentIndex
+                getAccessibility (resolveAccessControlLevel access) isPrivateWhenReachedBinding node.ParentIndex
             | TypeSimpleRepresentation(_)
             | Pattern(_) -> AccessControlLevel.Public
             | MemberDefinition(_) ->
@@ -217,7 +217,7 @@ let getAccessibility (syntaxArray:AbstractSyntaxArray.Node []) i =
                 else getAccessibility state isPrivateWhenReachedBinding node.ParentIndex
             | Binding(SynBinding(access, _, _, _, _, _, _, _, _, _, _, _)) ->
                 if isPrivateWhenReachedBinding then AccessControlLevel.Private
-                else getAccessibility (isSynAccessPublic access) true node.ParentIndex
+                else getAccessibility (resolveAccessControlLevel access) true node.ParentIndex
             | EnumCase(_)
             | TypeRepresentation(_)
             | Type(_)

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
@@ -40,8 +40,8 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
-                let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
-                getPatternIdents accessibility (getValueOrFunctionIdents args.CheckInfo) true pattern
+                let accessControlLevel = getAccessControlLevel args.SyntaxArray args.NodeIndex
+                getPatternIdents accessControlLevel (getValueOrFunctionIdents args.CheckInfo) true pattern
             | Member | Property ->
                 getPatternIdents AccessControlLevel.Private getMemberIdents true pattern
             | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PrivateValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PrivateValuesNames.fs
@@ -36,7 +36,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
-                let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
+                let accessibility = getAccessControlLevel args.SyntaxArray args.NodeIndex
                 getPatternIdents accessibility (getValueOrFunctionIdents args.CheckInfo) true pattern
             | _ -> Array.empty
         else

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/PublicValuesNames.fs
@@ -6,7 +6,7 @@ open FSharpLint.Framework.AstInfo
 open FSharpLint.Framework.Rules
 open FSharpLint.Rules.Helper.Naming
 
-let private getValueOrFunctionIdents typeChecker isPublic pattern =
+let private getValueOrFunctionIdents typeChecker accessControlLevel pattern =
     let checkNotUnionCase ident = fun () -> 
         typeChecker
         |> Option.map (fun checker -> isNotUnionCase checker ident)
@@ -24,7 +24,7 @@ let private getValueOrFunctionIdents typeChecker isPublic pattern =
         match List.tryLast longIdent.Lid with
         | Some ident when singleIdentifier ->
             let checkNotUnionCase = checkNotUnionCase ident
-            if isPublic = AccessControlLevel.Public && isNotActivePattern ident then
+            if accessControlLevel = AccessControlLevel.Public && isNotActivePattern ident then
                 (ident, ident.idText, Some checkNotUnionCase)
                 |> Array.singleton
             else
@@ -40,7 +40,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
         if not (isLiteral attributes || isExtern attributes) then
             match identifierTypeFromValData valData with
             | Value | Function ->
-                let accessibility = getAccessibility args.SyntaxArray args.NodeIndex
+                let accessibility = getAccessControlLevel args.SyntaxArray args.NodeIndex
                 getPatternIdents accessibility (getValueOrFunctionIdents args.CheckInfo) true pattern
             | _ -> Array.empty
         else


### PR DESCRIPTION
Renamed some functions and/or parameters
related to AccessControlLevel to make their
intent more clear.