### PR TITLE
Update Paket to v7.2.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "paket": {
-      "version": "5.252.0",
+      "version": "7.2.1",
       "commands": [
         "paket"
       ]


### PR DESCRIPTION
Paket updated with ```dotnet tool update paket```.

Reasoning: 

The 5.252.0 version it currently uses doesn't understand .NET 6, so it needs to be updated to a newer version.
As the new version still works with .NET 5, it could be updated as a stand alone step to reduce the number of changes needed later.