### PR TITLE
Fix for issue #341

### DIFF
--- a/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
+++ b/src/FSharpLint.Core/Rules/Hints/HintMatcher.fs
@@ -256,7 +256,7 @@ module private MatchExpression =
             | _ -> NoMatch
         | Expression.Variable(var) ->
             match expr with
-            | AstNode.Expression(expr) -> arguments.MatchedVariables.Add(var, expr)
+            | AstNode.Expression(expr) -> arguments.MatchedVariables.TryAdd(var, expr) |> ignore
             | _ -> ()
             Match([])
         | Expression.Wildcard ->


### PR DESCRIPTION
The cause of this crash is that there are multiple rules hit for a variable.
Right now what happens: FSharpLint crashes and doesn't produce output.

Instead, if we just ignore the failure of adding a rule failure to a single line of code, the end-user would produce a result.
After fixing the issue the end-user can re-run the lint again and see if the earlier ignored rule still hits or not.
