### PR TITLE
Update the 'setup-dotnet' action in the CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .Net Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
     - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore tools

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore tools


### PR DESCRIPTION
Just an observation that there are several warnings in the CI builds about using old versions of the actions:

![image](https://github.com/fsprojects/FSharpLint/assets/1178570/0832435e-d027-44ff-9ade-af72b9a6f211)

I don't know how important it actually is, but it does remove a bit of noise, so here it is if its considered useful