### PR TITLE
[RFC] Use 'Packages' storage for the docs when doing a paket restore

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -29,7 +29,7 @@ group Docs
   source https://api.nuget.org/v3/index.json
 
   framework: netstandard2.0
-  storage: symlink
+  storage: packages
 
   nuget FSharp.Formatting ~> 4.0
   nuget Markdig

--- a/paket.lock
+++ b/paket.lock
@@ -913,7 +913,7 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3)
 
 GROUP Docs
-STORAGE: SYMLINK
+STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json


### PR DESCRIPTION
I've been trying to get everything [building with .NET 6](https://github.com/fsprojects/FSharpLint/pull/606) and the related tooling, and have been getting CI build failures in the macOS builds, with errors that look like those described at https://github.com/fsprojects/Paket/issues/3767

It looks like changing Paket to use 'packages' storage instead of 'symlink' avoids that issue, by putting the restored nuget packages directly into the local packages folder instead of symlinking them. (I don't know much about this Paket feature - the docs suggest its for reducing disk usage by avoid duplicates, which might not really be an issue for the builds?)

On a related note, we also have this issue - https://github.com/fsprojects/FSharpLint/issues/578 - where you have to either run the build as admin on windows or set some extra OS options otherwise the package restore will fail. I think this change would avoid that as well.

Note: Changing the paket storage to 'none' helped with package restore issue, but caused the 'docs' build to break for me because the Fornax tool couldn't find the libraries, whereas it works when set to 'packages'