### PR TITLE
CI(publish): upload to nuget before creating GitHub release

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,7 +3,7 @@ name: .NET 5.0
 on: [push, pull_request]
 
 jobs:
-  build:
+  buildAndTest:
 
     strategy:
       matrix:
@@ -24,5 +24,5 @@ jobs:
       run: dotnet tool restore
     - name: Restore dependencies
       run: dotnet restore
-    - name: Run build
+    - name: Build and run tests
       run: dotnet fake build -t Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         version: ${{ github.ref }}
         path: ./CHANGELOG.md
+    - name: Upload binaries to nuget
+      env:
+        nuget-key: ${{ secrets.NUGET_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: dotnet fake build -t Push
     - name: Create Release
       id: create_release
       uses: actions/create-release@latest
@@ -51,8 +56,3 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
-    - name: Upload binaries to nuget
-      env:
-        nuget-key: ${{ secrets.NUGET_KEY }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: dotnet fake build -t Push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,9 @@ jobs:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore tools
       run: dotnet tool restore
-    - name: Run Test
+    - name: Build
       run: dotnet fake build
-    - name: Run build
+    - name: Pack
       run: dotnet fake build -t Pack
     - name: Get Changelog Entry
       id: changelog_reader

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,4 +15,4 @@ After pushing the tag to remote, the publish pipeline will be kicked off which w
 * Github secret: `NUGET_KEY`.
   * This is the API key from nuget, used to push the package to nuget.
   * At the moment the key lives under `knocte`'s nuget account, but maybe the `fsprojects` account should also be able to create an applicable API key.
-  * "Expires in 12 months" from 2023/11/23 (NOTE: if you forget to update the key after it has expired, and then pushing to nuget fails, don't forget to delete the release in github before retrying the CI workflow.)
+  * "Expires in 12 months" from 2023/11/23


### PR DESCRIPTION
This is so that if a nuget upload fails because the NUGET_KEY secret has expired, a re-run of the workflow (after updating the secret) would just work (instead of failing because the GitHub release already exists).