### PR TITLE
Add the BenchmarkDotNet artifacts folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ tests/FSharpLint.FunctionalTest.TestedProject/FSharpLintMSBuildTaskTest/
 DesignTimeBuild/
 .vs/
 .ionide/
+
+# BenchmarkDotNet Results
+tests/FSharpLint.Benchmarks/BenchmarkDotNet.Artifacts


### PR DESCRIPTION
I was having a go at running the benchmark project, and all the artifacts got listed as changes in Git - and I don't think they should?