### PR TITLE
CI: remove redundant .NET install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .Net Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
It was installing .NETCore 3.1 first, to later install .NET5.