### PR TITLE
Rule that suggest using auto-property

### DIFF
--- a/docs/content/how-tos/rule-configuration.md
+++ b/docs/content/how-tos/rule-configuration.md
@@ -119,3 +119,4 @@ The following rules can be specified for linting.
 - [FavourStaticEmptyFields (FL0076)](rules/FL0076.html)
 - [AvoidSinglePipeOperator (FL0077)](rules/FL0077.html)
 - [AsyncExceptionWithoutReturn (FL0078)](rules/FL0078.html)
+- [SuggestUseAutoProperty (FL0079)](rules/FL0079.html)

--- a/docs/content/how-tos/rules/FL0079.md
+++ b/docs/content/how-tos/rules/FL0079.md
@@ -1,0 +1,27 @@
+---
+title: FL0079
+category: how-to
+hide_menu: true
+---
+
+# SuggestUseAutoProperty (FL0079)
+
+*Introduced in `0.21.6`*
+
+## Cause
+
+Suggest usage of auto-property (`member val Foo`) when `member self.Foo` is unnecessary.
+
+## Rationale
+
+Cleaner code.
+
+## How To Fix
+
+Use auto-property (`member val`) for properties that only return immutable value.
+
+## Rule Settings
+
+    {
+        "suggestUseAutoProperty": { "enabled": false }
+    }

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -321,7 +321,8 @@ type ConventionsConfig =
       numberOfItems:NumberOfItemsConfig option
       binding:BindingConfig option
       favourReRaise:EnabledConfig option
-      favourConsistentThis:RuleConfig<FavourConsistentThis.Config> option }
+      favourConsistentThis:RuleConfig<FavourConsistentThis.Config> option
+      suggestUseAutoProperty:EnabledConfig option}
 with
     member this.Flatten() =
         [|
@@ -342,6 +343,7 @@ with
             this.naming |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
             this.numberOfItems |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
             this.binding |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
+            this.suggestUseAutoProperty |> Option.bind (constructRuleIfEnabled SuggestUseAutoProperty.rule) |> Option.toArray
         |] |> Array.concat
 
 type TypographyConfig =
@@ -460,7 +462,8 @@ type Configuration =
       MaxLinesInFile:RuleConfig<MaxLinesInFile.Config> option
       TrailingNewLineInFile:EnabledConfig option
       NoTabCharacters:EnabledConfig option
-      NoPartialFunctions:RuleConfig<NoPartialFunctions.Config> option }
+      NoPartialFunctions:RuleConfig<NoPartialFunctions.Config> option
+      SuggestUseAutoProperty:EnabledConfig option }
 with
     static member Zero = {
         Global = None
@@ -547,6 +550,7 @@ with
         TrailingNewLineInFile = None
         NoTabCharacters = None
         NoPartialFunctions = None
+        SuggestUseAutoProperty = None
     }
 
 // fsharplint:enable RecordFieldNames

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Rules\Conventions\FavourReRaise.fs" />
     <Compile Include="Rules\Conventions\FavourConsistentThis.fs" />
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
+    <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithTooManyArgumentsHelper.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\FailwithWithSingleArgument.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithSingleArgument.fs" />

--- a/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -9,7 +9,7 @@ open FSharpLint.Framework.Rules
 
 let rec private isImmutableValueExpression (args: AstNodeRuleParams) (expression: SynExpr) =
     match expression with
-    | SynExpr.Const (constant, range) -> true
+    | SynExpr.Const (_constant, _range) -> true
     | SynExpr.Ident ident ->
         let isMutableVariable =
             match args.GetParents args.NodeIndex with

--- a/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -1,0 +1,19 @@
+﻿module FSharpLint.Rules.SuggestUseAutoProperty
+
+open System
+open FSharpLint.Framework
+open FSharpLint.Framework.Suggestion
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.Rules
+
+let private runner (args: AstNodeRuleParams) =
+    failwith "Not yet implemented"
+
+let rule =
+    { Name = "SuggestUseAutoProperty"
+      Identifier = Identifiers.SuggestUseAutoProperty
+      RuleConfig =
+        { AstNodeRuleConfig.Runner = runner
+          Cleanup = ignore } }
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -7,6 +7,43 @@ open FSharp.Compiler.Syntax
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
+let rec private isImmutableValueExpression (args: AstNodeRuleParams) (expression: SynExpr) =
+    match expression with
+    | SynExpr.Const (constant, range) -> true
+    | SynExpr.Ident ident ->
+        let isMutableVariable =
+            match args.GetParents args.NodeIndex with
+            | TypeDefinition (SynTypeDefn (_, SynTypeDefnRepr.ObjectModel (_, members, _), _, _, _)) :: _ ->
+                members
+                |> List.exists (fun (memberDef: SynMemberDefn) ->
+                    match memberDef with
+                    | SynMemberDefn.LetBindings (bindings, _, _, _) ->
+                        bindings
+                        |> List.exists (fun (SynBinding (_, _, _, isMutable, _, _, _, headPat, _, _, _, _)) ->
+                            match headPat with
+                            | SynPat.Named (_, bindingIdent, _, _, _) when isMutable ->
+                                bindingIdent.idText = ident.idText
+                            | _ -> false)
+                    | _ -> false)
+            | _ -> false
+
+        not isMutableVariable
+    | SynExpr.ArrayOrList (_, elements, _) ->
+        elements
+        |> List.forall (isImmutableValueExpression args)
+    | SynExpr.ArrayOrListOfSeqExpr (_, SynExpr.CompExpr(true, _, innerExpr, _), _) ->
+        isImmutableValueExpression args innerExpr
+        || isImmutableSequentialExpression args innerExpr
+    | _ -> false
+
+and isImmutableSequentialExpression args expression =
+    match expression with
+    | SynExpr.Sequential (_, _, expr1, expr2, _) ->
+        isImmutableValueExpression args expr1
+        && (isImmutableSequentialExpression args expr2
+            || isImmutableValueExpression args expr2)
+    | _ -> false
+
 let private runner (args: AstNodeRuleParams) =
     match args.AstNode with
     | MemberDefinition
@@ -15,56 +52,31 @@ let private runner (args: AstNodeRuleParams) =
                 (
                     SynBinding
                         (
-                            accessibility,
-                            kind,
+                            _accessibility,
+                            _kind,
                             _,
                             false,
                             _attributes,
                             _xmlDoc,
-                            valData,
+                            _valData,
                             SynPat.LongIdent (_, _, _, argPats, _, _),
-                            returnInfo,
+                            _returnInfo,
                             expr,
-                            bindingRange,
+                            _bindingRange,
                             _
                         ),
                     memberRange
                 )
         ) ->
-        match (expr, argPats) with
-        | (_, SynArgPats.Pats pats) when pats.Length > 0 -> // non-property member
+        match expr, argPats with
+        | _, SynArgPats.Pats pats when pats.Length > 0 -> // non-property member
             Array.empty
-        | (SynExpr.Const (constant, range), _) ->
+        | expression, _ when isImmutableValueExpression args expression ->
             { Range = memberRange
               Message = Resources.GetString "RulesSuggestUseAutoProperty"
               SuggestedFix = None
               TypeChecks = List.Empty }
             |> Array.singleton
-        | (SynExpr.Ident ident, _) ->
-            let isMutableVariable =
-                match args.GetParents args.NodeIndex with
-                | TypeDefinition (SynTypeDefn (_, SynTypeDefnRepr.ObjectModel (_, members, _), _, _, _)) :: _ ->
-                    members
-                    |> List.exists (fun (memberDef: SynMemberDefn) ->
-                        match memberDef with
-                        | SynMemberDefn.LetBindings (bindings, _, _, _) ->
-                            bindings
-                            |> List.exists (fun (SynBinding (_, _, _, isMutable, _, _, _, headPat, _, _, _, _)) ->
-                                match headPat with
-                                | SynPat.Named (_, bindingIdent, _, _, _) when isMutable ->
-                                    bindingIdent.idText = ident.idText
-                                | _ -> false)
-                        | _ -> false)
-                | _ -> false
-
-            if isMutableVariable then
-                Array.empty
-            else
-                { Range = memberRange
-                  Message = Resources.GetString "RulesSuggestUseAutoProperty"
-                  SuggestedFix = None
-                  TypeChecks = List.Empty }
-                |> Array.singleton
         | _ -> Array.empty
     | _ -> Array.empty
 

--- a/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -58,7 +58,7 @@ let private runner (args: AstNodeRuleParams) =
                             false,
                             _attributes,
                             _xmlDoc,
-                            _valData,
+                            SynValData(Some(memberFlags), _, _),
                             SynPat.LongIdent (_, _, _, argPats, _, _),
                             _returnInfo,
                             expr,
@@ -67,7 +67,7 @@ let private runner (args: AstNodeRuleParams) =
                         ),
                     memberRange
                 )
-        ) ->
+        ) when memberFlags.IsInstance ->
         match expr, argPats with
         | _, SynArgPats.Pats pats when pats.Length > 0 -> // non-property member
             Array.empty

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -83,3 +83,4 @@ let AvoidTooShortNames = identifier 75
 let FavourStaticEmptyFields = identifier 76
 let AvoidSinglePipeOperator = identifier 77
 let AsyncExceptionWithoutReturn = identifier 78
+let SuggestUseAutoProperty = identifier 79

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -352,6 +352,6 @@
     <value>You should use the 'return' keyword when raising an exception in an async computation expression.</value>
   </data>
   <data name="RulesSuggestUseAutoProperty" xml:space="preserve">
-    <value>Consider giving auto-properties via the "val" keyword</value>
+    <value>Consider using auto-properties via the 'val' keyword.</value>
   </data>
 </root>

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -351,4 +351,7 @@
   <data name="RulesAsyncExceptionWithoutReturn" xml:space="preserve">
     <value>You should use the 'return' keyword when raising an exception in an async computation expression.</value>
   </data>
+  <data name="RulesSuggestUseAutoProperty" xml:space="preserve">
+    <value>Consider giving auto-properties via the "val" keyword</value>
+  </data>
 </root>

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -274,6 +274,7 @@
             "symbol": "this"
         }
     },
+    "suggestUseAutoProperty": { "enabled": false },
     "avoidTooShortNames": { "enabled": false },
     "asyncExceptionWithoutReturn": { "enabled": false },
     "indentation": {

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="Rules\Conventions\FavourConsistentThis.fs" />
     <Compile Include="Rules\Conventions\AvoidTooShortNames.fs" />
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
+    <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
     <Compile Include="Rules\Conventions\Naming\NamingHelpers.fs" />
     <Compile Include="Rules\Conventions\Naming\InterfaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ExceptionNames.fs" />

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -18,6 +18,25 @@ type Foo(content: int) =
         Assert.IsTrue(this.ErrorsExist)
 
     [<Test>]
+    member this.``Should suggest usage of auto-property for property that only returns literal`` () =
+        this.Parse """
+type Foo() =
+    member self.Content = 42
+"""
+
+        Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Shouldn't suggest usage of auto-property for property that returns mutable value``() =
+        this.Parse """
+type Foo(content: int) =
+    let mutable mutableContent = content
+    member self.Content = mutableContent
+"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
     member this.``Shouldn't suggest usage of auto-property for non-property member``() =
         this.Parse """
 type Foo(content: int) =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -1,0 +1,28 @@
+﻿module FSharpLint.Core.Tests.Rules.Conventions.SuggestUseAutoProperty
+
+open NUnit.Framework
+open FSharpLint.Framework.Rules
+open FSharpLint.Rules
+
+[<TestFixture>]
+type TestSuggestUseAutoProperty() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(SuggestUseAutoProperty.rule)
+
+    [<Test>]
+    member this.``Should suggest usage of auto-property for property that only returns immutable value`` () =
+        this.Parse """
+type Foo(content: int) =
+    member self.Content = content
+"""
+
+        Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Shouldn't suggest usage of auto-property for non-property member``() =
+        this.Parse """
+type Foo(content: int) =
+    member self.Content() = content
+"""
+
+        Assert.IsTrue(this.NoErrorsExist)
+

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -18,6 +18,24 @@ type Foo(content: int) =
         Assert.IsTrue(this.ErrorsExist)
 
     [<Test>]
+    member this.``Should suggest usage of auto-property for property that only returns immutable value (this self-identifier)`` () =
+        this.Parse """
+type Foo(content: int) =
+    member this.Content = content
+"""
+
+        Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Should suggest usage of auto-property for property that only returns immutable value (__ self-identifier)`` () =
+        this.Parse """
+type Foo(content: int) =
+    member __.Content = content
+"""
+
+        Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
     member this.``Should suggest usage of auto-property for property that only returns literal`` () =
         this.Parse """
 type Foo() =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -72,3 +72,18 @@ type Foo() =
 """
 
         Assert.IsTrue(this.NoErrorsExist)
+
+    [<Test>]
+    member this.``Quick fix for property that only returns immutable value`` () =
+        let source = """
+type Foo(content: int) =
+    member self.Content = content
+"""
+    
+        let expected = """
+type Foo(content: int) =
+    member val Content = content
+"""
+
+        this.Parse source
+        Assert.AreEqual(expected, this.ApplyQuickFix source)

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -45,3 +45,21 @@ type Foo(content: int) =
 
         Assert.IsTrue(this.NoErrorsExist)
 
+
+    [<Test>]
+    member this.``Should suggest usage of auto-property for for property that only returns list of immutable values``() =
+        this.Parse """
+type Foo(content: int) =
+    member self.Content = [ 42 ]
+"""
+
+        Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Should suggest usage of auto-property for for property that only returns array of immutable values``() =
+        this.Parse """
+type Foo(content: int) =
+    member self.Content = [| content; 42 |]
+"""
+
+        Assert.IsTrue(this.ErrorsExist)

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -63,3 +63,12 @@ type Foo(content: int) =
 """
 
         Assert.IsTrue(this.ErrorsExist)
+
+    [<Test>]
+    member this.``Should not suggest usage of auto-property for static property`` () =
+        this.Parse """
+type Foo() =
+    static member Content = 42
+"""
+
+        Assert.IsTrue(this.NoErrorsExist)


### PR DESCRIPTION
Add rule that suggests usage of auto-property (`member val Foo`) when `member self.Foo` is unnecessary.

Fixes #596.