### PR TITLE
FavourStaticEmptyFields: fix issue 630

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/FavourStaticEmptyFields.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourStaticEmptyFields.fs
@@ -56,8 +56,8 @@ let private runner (args: AstNodeRuleParams) =
                     let suggestions = generateError range idText emptyLiteralType
                     suggestions |> Array.map (fun suggestion -> { suggestion with TypeChecks = Option.toList typeCheck }))
             | _ -> Array.empty
-        | SynExpr.ArrayOrList (_, id, range) when "[]" = sprintf "%A" id || "[||]" = sprintf "%A" id ->
-            (range, sprintf "%A" id, None, getEmptyLiteralType (sprintf "%A" id))
+        | SynExpr.ArrayOrList (isArray, id, range) when "[]" = sprintf "%A" id || "[||]" = sprintf "%A" id ->
+            (range, sprintf "%A" id, None, (if isArray then EmptyArrayLiteral else EmptyListLiteral))
             |> Array.singleton
             |> Array.collect (fun (range, idText, typeCheck, emptyLiteralType) ->
                 let suggestions = generateError range idText emptyLiteralType
@@ -77,8 +77,8 @@ let private runner (args: AstNodeRuleParams) =
             |> Array.collect (fun (range, idText, typeCheck, emptyLiteralType) ->
                 let suggestions = generateError range idText emptyLiteralType
                 suggestions |> Array.map (fun suggestion -> { suggestion with TypeChecks = Option.toList typeCheck }))
-        | SynExpr.ArrayOrList (_, id, range) when "[]" = sprintf "%A" id || "[||]" = sprintf "%A" id ->
-            (range, sprintf "%A" id, None, getEmptyLiteralType (sprintf "%A" id))
+        | SynExpr.ArrayOrList (isArray, id, range) when "[]" = sprintf "%A" id || "[||]" = sprintf "%A" id ->
+            (range, sprintf "%A" id, None, (if isArray then EmptyArrayLiteral else EmptyListLiteral))
             |> Array.singleton
             |> Array.collect (fun (range, idText, typeCheck, emptyLiteralType) ->
                 let suggestions = generateError range idText emptyLiteralType

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourStaticEmptyFields.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourStaticEmptyFields.fs
@@ -13,30 +13,35 @@ type TestConventionsFavourStaticEmptyFields() =
         this.Parse "let foo = \"\""
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "String.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_2() =
         this.Parse "System.Console.WriteLine \"\""
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "String.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_3() =
         this.Parse "let aList = []"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "List.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_4() =
         this.Parse "let aList = [ ]"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "List.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_5() =
         this.Parse "System.Console.WriteLine([].Length)"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "List.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_6() =
@@ -48,24 +53,28 @@ let foo a =
         "" """
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "String.Empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_7() =
         this.Parse "let anArray = [||]"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "Array.empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_8() =
         this.Parse "let anArray = [| |]"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "Array.empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldProduceError_9() =
         this.Parse "System.Console.WriteLine([||].Length)"
 
         Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue (this.ErrorMsg.Contains "Array.empty")
 
     [<Test>]
     member this.FavourStaticEmptyFieldsShouldNotProduceError_1() =


### PR DESCRIPTION
Added checks for error message containing substitution that is appropriate for given data type (array or list) in `FavourStaticEmptyFields` tests. E.g. `Array.empty` should be suggested for replacing `[||]`.

Fixed bug in FavourStaticEmptyFields rule that caused wrong suggestion for arrays.

Simplified FavourStaticEmptyFields rule by removing unnecessary code.

Fixes https://github.com/fsprojects/FSharpLint/issues/630