### PR TITLE
AvoidTooShortNames: honor "let!" declarations

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/AvoidTooShortNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/AvoidTooShortNames.fs
@@ -51,6 +51,8 @@ let private getParameterWithBelowMinimumLength (pats: SynPat list): (Ident * str
 
 let private getIdentifiers (args:AstNodeRuleParams) =
     match args.AstNode with
+    | AstNode.Expression(SynExpr.LetOrUseBang(_, _, _, pat, _, _, _, _)) ->
+        getParameterWithBelowMinimumLength [pat]
     | AstNode.Match(SynMatchClause(namePattern, _, _, _, _)) ->
         getParameterWithBelowMinimumLength [namePattern]
     | AstNode.Binding(SynBinding(_, _, _, _, _, _, _, pattern, _, _, _, _)) ->

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidTooShortNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidTooShortNames.fs
@@ -152,3 +152,13 @@ async {
 } |> Async.RunSynchronously |> ignore<int>"""
 
         Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.AvoidTooShortNamesShouldProduceError_14() =
+        this.Parse """
+async {
+    let! result = async { return 1 + 2 }
+    return result
+} |> Async.RunSynchronously |> ignore<int>"""
+
+        Assert.IsTrue this.NoErrorsExist

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidTooShortNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidTooShortNames.fs
@@ -142,3 +142,13 @@ match foo with
 """
         Assert.IsTrue(this.ErrorExistsAt(3, 7))
         Assert.IsFalse(this.ErrorExistsAt(3, 14))
+
+    [<Test>]
+    member this.AvoidTooShortNamesShouldProduceError_13() =
+        this.Parse """
+async {
+    let! z = async { return 1 + 2 }
+    return z
+} |> Async.RunSynchronously |> ignore<int>"""
+
+        Assert.IsTrue this.ErrorsExist


### PR DESCRIPTION
"Bang" keywords, such as let!, are not taken into account by AvoidTooShortNames.