### PR TITLE
Fix bug in AvoidSinglePipeOperator

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/AvoidSinglePipeOperator.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/AvoidSinglePipeOperator.fs
@@ -28,21 +28,8 @@ let runner (args: AstNodeRuleParams) =
                     | SynExpr.Ident ident ->
                         if ident.idText = "op_PipeRight" then
                             match argExpr with
-                            | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, _argExpr, range) ->
-                                match funcExpr with
-                                | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, _argExpr, range) ->
-                                    match funcExpr with
-                                    | SynExpr.Ident ident ->
-                                        if ident.idText = "op_PipeRight" then
-                                            Array.empty
-                                        else
-                                            errors range
-                                    | _ ->
-                                        errors range
-                                | SynExpr.Ident _ident ->
-                                    Array.empty                                
-                                | _ ->
-                                    errors range
+                            | SynExpr.App(_exprAtomicFlag, _isInfix, _funcExpr, _argExpr, _range) ->
+                                Array.empty 
                             | _ ->
                                 errors range
                         else

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
@@ -84,3 +84,13 @@ let someFunc someParam =
 """
 
         Assert.IsFalse this.ErrorsExist
+
+
+    [<Test>]
+    member this.``Use pipe operator once to avoid parenthesis on expression with function application``() =
+        this.Parse """
+let someFunc someParam =
+    someOtherFunc1 someParam someParam2 |> someOtherFunc3
+"""
+
+        Assert.IsFalse this.ErrorsExist


### PR DESCRIPTION
Fix bug in AvoidSinglePipeOperator when it gives false positive on expressions with function application.

E.g.
```
someOtherFunc1 someParam someParam2 |> someOtherFunc3
```

Added failing test for this case.