### PR TITLE
CI: change publish&docs pipelines to run on Linux

### DIFF
--- a/.github/workflows/build+test+publish.yml
+++ b/.github/workflows/build+test+publish.yml
@@ -37,13 +37,10 @@ jobs:
     - name: Run FSharpLint on itself
       run: dotnet fake build -t SelfCheck
 
-  publish:
-    needs: buildAndTest
 
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  deployReleaseBinaries:
+    needs: buildAndTest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
@@ -92,13 +89,9 @@ jobs:
         file_glob: true
 
 
-  docsUpdate:
-    needs: publish
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  deployReleaseDocs:
+    needs: deployReleaseBinaries
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -108,7 +101,7 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     # old .NET required by old fornax version
-    - name: Setup .NET
+    - name: Setup old .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x

--- a/.github/workflows/build+test+publish.yml
+++ b/.github/workflows/build+test+publish.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -97,7 +97,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
This shouldn't change anything, other than the fact that
it may make CI slightly faster (judging by the timing of
the buildAndTest job pipeline, where the Ubuntu one is
always faster[1] than the macOS&Windows ones).

[1] ~9mins + ~2min => ~4mins + ~1min