### PR TITLE
build.fsx,RELEASE.md: improve preRelease version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Package | Version
 
 ## How to release
 
-1. Update [CHANGELOG.md](./CHANGELOG.md) by adding new entry (`## [X.Y.Z]`) and commit it.
-2. Create version tag (`git tag vX.Y.Z`)
-3. Push the tag to the repo `git push origin vX.Y.Z` - this will start CI process that will create a GitHub release and publish the packages to NuGet
+Please [read the Releasing Guidelines](./RELEASE.md) if you're a maintainer.
 
 ## How to contribute
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
 # Releasing a new version of FSharpLint
 
-1. Update the [changelog](CHANGELOG.md) since last release and get the changes onto master.
+1. Update the [changelog](CHANGELOG.md) since last release and get the changes onto master,
+choosing a version that increases the Major or Minor part of the version by 1, or the Revision
+part of the version by 2, e.g.: 0.20.2 -> 0.23.0 or 0.20.2 -> 1.0 or 0.20.2 -> 0.20.4.
 2. Tag the head of master with the version number in the format `vx.x.x` - for example: `v0.20.2`. 
 3. Push the tag to remote.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 # Releasing a new version of FSharpLint
 
-1. Update the [changelog](CHANGELOG.md) since last release and get the changes onto master,
-choosing a version that increases the Major or Minor part of the version by 1, or the Revision
-part of the version by 2, e.g.: 0.20.2 -> 0.23.0 or 0.20.2 -> 1.0 or 0.20.2 -> 0.20.4.
-2. Tag the head of master with the version number in the format `vx.x.x` - for example: `v0.20.2`. 
-3. Push the tag to remote.
+1. Update the [changelog](CHANGELOG.md) since last release: choose a version that increases the Major or Minor part of the version by 1, or the Revision
+part of the version by 2, e.g.: `0.20.2` -> `0.23.0` or `0.20.2` -> `1.0` or `0.20.2` -> `0.20.4`, and add the entry (`## [X.Y.Z]`) summarizing all the
+changes since the previous release (ideally one line per PR or commit).
+2. Commit and push the change onto master branch, and wait until CI finishes successfully.
+3. Tag the head of master with the version number in the format `vx.x.x` - e.g.: `git tag v0.20.4`.
+4. Push the tag to remote: `git push origin vX.Y.Z` - this will start CI process that will create a GitHub release and publish the packages to NuGet.
 
 After pushing the tag to remote, the publish pipeline will be kicked off which will:
 * Build the package

--- a/build.fsx
+++ b/build.fsx
@@ -76,8 +76,7 @@ let nugetVersion =
     | (_, false) ->
         let current = changelog.LatestEntry.NuGetVersion |> SemVer.parse
         let bumped = { current with
-                            Minor = current.Minor + 1u
-                            Patch = 0u
+                            Patch = current.Patch + 1u
                             Original = None
                             PreRelease = None }
         let bumpedBaseVersion = string bumped


### PR DESCRIPTION
After we added[1] support for uploading prerelease nuget packages, the versions chosen for these would increment the "Minor" part of the last version released. Example: if last released version was 0.21.7, then the prerelease uploaded would start as something like '0.22.0-date...'.

But this was not a good strategy because if the next version released after 0.21.7 is 0.21.8, then the 0.22.x packages would still be listed earlier than the 0.21.8 package in nuget, falsely implying that they are "ahead" of 0.21.8, when actually they were somewhere between 0.21.7 and 0.21.8.

Therefore we now make the increment happen at the Revision level instead of at the Minor level. So the prereleases after releasing a "0.21.8" for example, will start as '0.21.9-date...'.

And to be more in line with this change, we're gonna start the convention of adding +2 to the Revision every time we tag a release. This way, even numbers will give a "stable" aspect (as they are not a prerelease anyway): 0.21.8, 0.21.10, 0.21.12... And odd numbers will be prereleases: 0.21.9-date..., 0.21.11-date...

[1] 9618a8aa532b2dadc47ff5002d0adf678865c889