### PR TITLE
A new rule that finds used underscore prefixed elements

### DIFF
--- a/docs/content/how-tos/rule-configuration.md
+++ b/docs/content/how-tos/rule-configuration.md
@@ -122,3 +122,4 @@ The following rules can be specified for linting.
 - [SuggestUseAutoProperty (FL0079)](rules/FL0079.html)
 - [UnnestedFunctionNames (FL0080)](rules/FL0080.html)
 - [NestedFunctionNames (FL0081)](rules/FL0081.html)
+- [UsedUnderscorePrefixedElements (FL0082)](rules/FL0082.html)

--- a/docs/content/how-tos/rules/FL0082.md
+++ b/docs/content/how-tos/rules/FL0082.md
@@ -1,0 +1,30 @@
+---
+title: FL0082
+category: how-to
+hide_menu: true
+---
+
+# UsedUnderscorePrefixedElements (FL0082)
+
+*Introduced in `0.23.0`*
+
+## Cause
+
+An underscore-prefixed element is being used.
+
+## Rationale
+
+Underscore (_) or underscore-prefixed elements are normally used for things that are not being used.
+
+## How To Fix
+
+Remove the underscore prefix or avoid using that element in the code.
+
+## Rule Settings
+
+    {
+        "usedUnderscorePrefixedElements": {
+            "enabled": true
+        }
+    }
+

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -322,7 +322,8 @@ type ConventionsConfig =
       binding:BindingConfig option
       favourReRaise:EnabledConfig option
       favourConsistentThis:RuleConfig<FavourConsistentThis.Config> option
-      suggestUseAutoProperty:EnabledConfig option}
+      suggestUseAutoProperty:EnabledConfig option
+      usedUnderscorePrefixedElements:EnabledConfig option }
 with
     member this.Flatten() =
         [|
@@ -338,6 +339,7 @@ with
             this.reimplementsFunction |> Option.bind (constructRuleIfEnabled ReimplementsFunction.rule) |> Option.toArray
             this.canBeReplacedWithComposition |> Option.bind (constructRuleIfEnabled CanBeReplacedWithComposition.rule) |> Option.toArray
             this.avoidSinglePipeOperator|> Option.bind (constructRuleIfEnabled AvoidSinglePipeOperator.rule) |> Option.toArray
+            this.usedUnderscorePrefixedElements |> Option.bind (constructRuleIfEnabled UsedUnderscorePrefixedElements.rule) |> Option.toArray
             this.raiseWithTooManyArgs |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
             this.sourceLength |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
             this.naming |> Option.map (fun config -> config.Flatten()) |> Option.toArray |> Array.concat
@@ -410,6 +412,7 @@ type Configuration =
       ReimplementsFunction:EnabledConfig option
       CanBeReplacedWithComposition:EnabledConfig option
       AvoidSinglePipeOperator:EnabledConfig option
+      UsedUnderscorePrefixedElements:EnabledConfig option
       FailwithBadUsage:EnabledConfig option
       RaiseWithSingleArgument:EnabledConfig option
       FailwithWithSingleArgument:EnabledConfig option
@@ -497,6 +500,7 @@ with
         ReimplementsFunction = None
         CanBeReplacedWithComposition = None
         AvoidSinglePipeOperator = None
+        UsedUnderscorePrefixedElements = None
         FailwithWithSingleArgument = None
         FailwithBadUsage = None
         RaiseWithSingleArgument = None
@@ -647,6 +651,7 @@ let flattenConfig (config:Configuration) =
             config.ReimplementsFunction |> Option.bind (constructRuleIfEnabled ReimplementsFunction.rule)
             config.CanBeReplacedWithComposition |> Option.bind (constructRuleIfEnabled CanBeReplacedWithComposition.rule)
             config.AvoidSinglePipeOperator |> Option.bind (constructRuleIfEnabled AvoidSinglePipeOperator.rule)
+            config.UsedUnderscorePrefixedElements |> Option.bind (constructRuleIfEnabled UsedUnderscorePrefixedElements.rule)
             config.FailwithBadUsage |> Option.bind (constructRuleIfEnabled FailwithBadUsage.rule)
             config.RaiseWithSingleArgument |> Option.bind (constructRuleIfEnabled RaiseWithSingleArgument.rule)
             config.FailwithWithSingleArgument |> Option.bind (constructRuleIfEnabled FailwithWithSingleArgument.rule)

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="Rules\Conventions\FavourConsistentThis.fs" />
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
     <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
+    <Compile Include="Rules\Conventions\UsedUnderscorePrefixedElements.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithTooManyArgumentsHelper.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\FailwithWithSingleArgument.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithSingleArgument.fs" />

--- a/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -8,9 +8,46 @@ open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
 
-
 let runner (args:AstNodeRuleParams) =
-    Array.empty
+    
+    let mutable error = Array.empty
+    let mutable idents = List.empty<string>
+    match args.AstNode with
+        | AstNode.Expression (SynExpr.LetOrUse (isRecursive, isUse, bindings, body, range)) ->
+            match bindings.[0] with
+            | SynBinding(synAccessOption, synBindingKind, mustInline, isMutable, synAttributeLists, preXmlDoc, synValData, headPat, synBindingReturnInfoOption, synExpr, range, debugPointAtBinding) ->
+                match headPat with
+                | SynPat.Named(synPat, ident, isSelfIdentifier, synAccessOption, range) ->
+                    if ident.idText.StartsWith("_") then
+                        idents <- List.append idents [ident.idText]
+                | _ ->
+                    ()
+                    
+            match body with
+            | SynExpr.Sequential(debugPointAtSequential, isTrueSeq, synExpr, expr2, range) ->
+                match synExpr with
+                    | SynExpr.App(exprAtomicFlag, isInfix, funcExpr, argExpr, range) ->
+
+                        match argExpr with
+                            | SynExpr.Ident ident ->
+                                if (List.contains ident.idText idents) then
+                                    error <- ({
+                                        Range = range
+                                        Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
+                                        SuggestedFix = None
+                                        TypeChecks = []
+                                    } |> Array.singleton) 
+                                else
+                                    ()
+                            | _ ->
+                                ()
+                    | _ ->
+                        ()
+                | _ ->
+                    ()          
+        | _ -> ()
+        
+    error
 
 let rule =
     { Name = "UsedUnderscorePrefixedElements"

--- a/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -1,0 +1,19 @@
+module FSharpLint.Rules.UsedUnderscorePrefixedElements
+
+open System
+open FSharpLint.Framework
+open FSharpLint.Framework.Suggestion
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
+open FSharpLint.Framework.Rules
+
+
+
+let runner (args:AstNodeRuleParams) =
+    Array.empty
+
+let rule =
+    { Name = "UsedUnderscorePrefixedElements"
+      Identifier = Identifiers.UsedUnderscorePrefixedElements
+      RuleConfig = { AstNodeRuleConfig.Runner = runner; Cleanup = ignore } }
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -5,51 +5,45 @@ open System
 open FSharpLint.Framework
 open FSharpLint.Framework.Suggestion
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+open FSharp.Compiler.CodeAnalysis
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
-let private checkUsedIdent (previousIdent: Ident) (body: SynExpr) =
-    match body with
-    | SynExpr.Sequential(_debugPointAtSequential, _isTrueSeq, synExpr, _expr2, _range) ->
-        match synExpr with
-        | SynExpr.App(_exprAtomicFlag, _isInfix, _funcExpr, argExpr, range) ->
-            match argExpr with
-            | SynExpr.Ident ident ->
-                if previousIdent.idText = ident.idText then
-                    {
-                        Range = range
+let private checkUsedIdent (identifier: Ident) (usages: array<FSharpSymbolUse>) (scopeRange: Range) =
+    usages
+    |> Array.collect (fun usage ->
+        if not usage.IsFromDefinition && usage.Symbol.FullName = identifier.idText 
+            && ExpressionUtilities.rangeContainsOtherRange scopeRange usage.Range then
+            {
+                Range = usage.Range
+                Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
+                SuggestedFix = None
+                TypeChecks = List.Empty
+            } |> Array.singleton
+        else
+            Array.empty)
+
+let runner (args: AstNodeRuleParams) =
+    // hack to only run rule once
+    if args.NodeIndex = 0 then
+        match args.CheckInfo with
+        | Some checkResults -> 
+            checkResults.GetAllUsesOfAllSymbolsInFile() 
+            |> Seq.choose (fun usage ->
+                if not usage.IsFromDefinition && usage.Symbol.FullName.StartsWith "_" then
+                    Some {
+                        Range = usage.Range
                         Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
                         SuggestedFix = None
                         TypeChecks = List.Empty
-                    } |> Array.singleton
+                    }
                 else
-                    Array.empty
-            | _ ->
-                Array.empty
-        | _ ->
-            Array.empty
-    | _ ->
-        Array.empty  
-
-let runner (args: AstNodeRuleParams) =
-    
-    let error =
-        match args.AstNode with
-        | AstNode.Expression (SynExpr.LetOrUse (_isRecursive, _isUse, bindings, body, _range)) ->
-            match List.tryHead bindings with
-            | Some(SynBinding(_synAccessOption, _synBindingKind, _mustInline, _isMutable, _synAttributeLists, _preXmlDoc, _synValData, headPat, _synBindingReturnInfoOption, _synExpr, _range, _debugPointAtBinding)) ->
-                match headPat with
-                | SynPat.Named(_synPat, ident, _isSelfIdentifier, _synAccessOption, _range) ->
-                    if ident.idText.StartsWith "_" then
-                        checkUsedIdent ident body
-                    else
-                        Array.empty
-                | _ ->
-                    Array.empty
-            | _ -> Array.empty
-        | _ -> Array.empty
-        
-    error
+                    None)
+            |> Seq.toArray
+        | None -> Array.empty
+    else
+        Array.empty
 
 let rule =
     { Name = "UsedUnderscorePrefixedElements"

--- a/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -10,20 +10,6 @@ open FSharp.Compiler.CodeAnalysis
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
-let private checkUsedIdent (identifier: Ident) (usages: array<FSharpSymbolUse>) (scopeRange: Range) =
-    usages
-    |> Array.collect (fun usage ->
-        if not usage.IsFromDefinition && usage.Symbol.FullName = identifier.idText 
-            && ExpressionUtilities.rangeContainsOtherRange scopeRange usage.Range then
-            {
-                Range = usage.Range
-                Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
-                SuggestedFix = None
-                TypeChecks = List.Empty
-            } |> Array.singleton
-        else
-            Array.empty)
-
 let runner (args: AstNodeRuleParams) =
     // hack to only run rule once
     if args.NodeIndex = 0 then

--- a/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -1,51 +1,53 @@
 module FSharpLint.Rules.UsedUnderscorePrefixedElements
 
 open System
+
 open FSharpLint.Framework
 open FSharpLint.Framework.Suggestion
 open FSharp.Compiler.Syntax
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
+let private checkUsedIdent (previousIdent: Ident) (body: SynExpr) =
+    match body with
+    | SynExpr.Sequential(_debugPointAtSequential, _isTrueSeq, synExpr, _expr2, _range) ->
+        match synExpr with
+        | SynExpr.App(_exprAtomicFlag, _isInfix, _funcExpr, argExpr, range) ->
+            match argExpr with
+            | SynExpr.Ident ident ->
+                if previousIdent.idText = ident.idText then
+                    {
+                        Range = range
+                        Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
+                        SuggestedFix = None
+                        TypeChecks = List.Empty
+                    } |> Array.singleton
+                else
+                    Array.empty
+            | _ ->
+                Array.empty
+        | _ ->
+            Array.empty
+    | _ ->
+        Array.empty  
 
-let runner (args:AstNodeRuleParams) =
+let runner (args: AstNodeRuleParams) =
     
-    let mutable error = Array.empty
-    let mutable idents = List.empty<string>
-    match args.AstNode with
-        | AstNode.Expression (SynExpr.LetOrUse (isRecursive, isUse, bindings, body, range)) ->
-            match bindings.[0] with
-            | SynBinding(synAccessOption, synBindingKind, mustInline, isMutable, synAttributeLists, preXmlDoc, synValData, headPat, synBindingReturnInfoOption, synExpr, range, debugPointAtBinding) ->
+    let error =
+        match args.AstNode with
+        | AstNode.Expression (SynExpr.LetOrUse (_isRecursive, _isUse, bindings, body, _range)) ->
+            match List.tryHead bindings with
+            | Some(SynBinding(_synAccessOption, _synBindingKind, _mustInline, _isMutable, _synAttributeLists, _preXmlDoc, _synValData, headPat, _synBindingReturnInfoOption, _synExpr, _range, _debugPointAtBinding)) ->
                 match headPat with
-                | SynPat.Named(synPat, ident, isSelfIdentifier, synAccessOption, range) ->
-                    if ident.idText.StartsWith("_") then
-                        idents <- List.append idents [ident.idText]
+                | SynPat.Named(_synPat, ident, _isSelfIdentifier, _synAccessOption, _range) ->
+                    if ident.idText.StartsWith "_" then
+                        checkUsedIdent ident body
+                    else
+                        Array.empty
                 | _ ->
-                    ()
-                    
-            match body with
-            | SynExpr.Sequential(debugPointAtSequential, isTrueSeq, synExpr, expr2, range) ->
-                match synExpr with
-                    | SynExpr.App(exprAtomicFlag, isInfix, funcExpr, argExpr, range) ->
-
-                        match argExpr with
-                            | SynExpr.Ident ident ->
-                                if (List.contains ident.idText idents) then
-                                    error <- ({
-                                        Range = range
-                                        Message = String.Format(Resources.GetString ("RulesUsedUnderscorePrefixedElements"))
-                                        SuggestedFix = None
-                                        TypeChecks = []
-                                    } |> Array.singleton) 
-                                else
-                                    ()
-                            | _ ->
-                                ()
-                    | _ ->
-                        ()
-                | _ ->
-                    ()          
-        | _ -> ()
+                    Array.empty
+            | _ -> Array.empty
+        | _ -> Array.empty
         
     error
 

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -86,3 +86,4 @@ let AsyncExceptionWithoutReturn = identifier 78
 let SuggestUseAutoProperty = identifier 79
 let UnnestedFunctionNames = identifier 80
 let NestedFunctionNames = identifier 81
+let UsedUnderscorePrefixedElements = identifier 82

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -243,6 +243,9 @@
   <data name="RulesCanBeReplacedWithComposition" xml:space="preserve">
     <value>Lambda may be able to be replaced with composition. e.g. `fun x -&gt; x |&gt; isValid |&gt; not` could be replaced with `isValid &gt;&gt; not`.</value>
   </data>
+  <data name="RulesUsedUnderscorePrefixedElements" xml:space="preserve">
+    <value>Avoid using underscore-prefixed elements for the elements that are being used in the code.</value>
+  </data>
   <data name="RulesRedundantNewKeyword" xml:space="preserve">
     <value>Usage of `new` keyword here is redundant.</value>
   </data>

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -39,6 +39,7 @@
     "reimplementsFunction": { "enabled": true },
     "canBeReplacedWithComposition": { "enabled": true },
     "avoidSinglePipeOperator": { "enabled": false },
+    "usedUnderscorePrefixedElements": { "enabled": true },
     "failwithWithSingleArgument": { "enabled": true },
     "raiseWithSingleArgument": { "enabled": true },
     "nullArgWithSingleArgument": { "enabled": true },

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="Rules\Conventions\AvoidTooShortNames.fs" />
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
     <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
+    <Compile Include="Rules\Conventions\UsedUnderscorePrefixedElements.fs" />
     <Compile Include="Rules\Conventions\Naming\NamingHelpers.fs" />
     <Compile Include="Rules\Conventions\Naming\InterfaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ExceptionNames.fs" />

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -73,7 +73,18 @@ module MyModule =
         ()"""
 
         Assert.IsFalse this.ErrorsExist
+
+    [<Test>]
+    member this.``Use of underscore variable in function should not cause error``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let f _ = System.Random()
+        ()"""
+
+        Assert.IsFalse this.ErrorsExist
         
+    [<Test>]
     member this.``Using field with underscore prefix``() =
         this.Parse """
 type CustomerName(firstName) =
@@ -83,7 +94,7 @@ type CustomerName(firstName) =
 
         Assert.IsFalse this.ErrorsExist
         
-        
+    [<Test>]
     member this.``Using private member with underscore prefix``() =
         this.Parse """
 type CustomerName(firstName) =
@@ -93,6 +104,7 @@ type CustomerName(firstName) =
 
         Assert.IsFalse this.ErrorsExist
 
+    [<Test>]
     member this.``Using private property with underscore prefix``() =
         this.Parse """
 type CustomerName(firstName) =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -20,6 +20,39 @@ module MyModule =
         Assert.IsTrue this.ErrorsExist
 
     [<Test>]
+    member this.``Use variable with underscore prefix but not immediately after declaration``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let _random = System.Random()
+        ()
+        ()
+        _random"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``Use variable with underscore prefix inside some expression``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let _random = System.Random()
+        "someString" + _random.ToString()"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``Use variable with underscore prefix defined in tuple``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let (_random, x) = System.Random()
+        printfn "%A" _random
+        () """
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
     member this.``Not using variable with underscore prefix``() =
         this.Parse """
 module MyModule =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -1,0 +1,44 @@
+module FSharpLint.Core.Tests.Rules.Conventions.UsedUnderscorePrefixedElements
+
+open NUnit.Framework
+open FSharpLint.Rules
+open System
+
+[<TestFixture>]
+type TestConventionsUsedUnderscorePrefixedElements() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(UsedUnderscorePrefixedElements.rule)
+
+    [<Test>]
+    member this.``Use variable with underscore prefix``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let _random = System.Random()
+        printfn "%A" _random
+        () """
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``Not using variable with underscore prefix``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let _random = System.Random()
+        printfn "_random is not used here"
+        () """
+
+        Assert.IsFalse this.ErrorsExist
+        
+    [<Test>]
+    member this.``Using variable without underscore prefix``() =
+        this.Parse """
+module MyModule =
+    let MyFunc () =
+        let random = System.Random()
+        printfn "%A" random
+        () """
+
+        Assert.IsFalse this.ErrorsExist
+
+

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -49,5 +49,15 @@ type CustomerName(firstName) =
         printfn "%A" this._FirstName"""
 
         Assert.IsFalse this.ErrorsExist
+        
+        
+    member this.``Using private member with underscore prefix``() =
+        this.Parse """
+type CustomerName(firstName) =
+    member private this._FirstName = firstName
+    member this.MyFunc () =
+        printfn "%A" this._FirstName"""
+
+        Assert.IsFalse this.ErrorsExist
 
 

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -37,7 +37,16 @@ module MyModule =
     let MyFunc () =
         let random = System.Random()
         printfn "%A" random
-        () """
+        ()"""
+
+        Assert.IsFalse this.ErrorsExist
+        
+    member this.``Using field with underscore prefix``() =
+        this.Parse """
+type CustomerName(firstName) =
+    member this._FirstName = firstName
+    member this.MyFunc () =
+        printfn "%A" this._FirstName"""
 
         Assert.IsFalse this.ErrorsExist
 

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -60,4 +60,12 @@ type CustomerName(firstName) =
 
         Assert.IsFalse this.ErrorsExist
 
+    member this.``Using private property with underscore prefix``() =
+        this.Parse """
+type CustomerName(firstName) =
+    member val private _FirstName = firstName with get, set
+    
+    member this.MyFunc () =
+        printfn "%A" this._FirstName"""
 
+        Assert.IsFalse this.ErrorsExist

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/UsedUnderscorePrefixedElements.fs
@@ -1,8 +1,8 @@
 module FSharpLint.Core.Tests.Rules.Conventions.UsedUnderscorePrefixedElements
 
 open NUnit.Framework
+
 open FSharpLint.Rules
-open System
 
 [<TestFixture>]
 type TestConventionsUsedUnderscorePrefixedElements() =


### PR DESCRIPTION
Supersedes #591 

Fixes https://github.com/fsprojects/FSharpLint/issues/573