### PR TITLE
Add quickfix suggestions for several rules

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Binding/TupleOfWildcards.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Binding/TupleOfWildcards.fs
@@ -7,7 +7,7 @@ open FSharp.Compiler.Syntax
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
-let private checkTupleOfWildcards pattern identifier =
+let private checkTupleOfWildcards fileContents pattern identifier identifierRange =
     let rec isWildcard = function
         | SynPat.Paren(pattern, _) -> isWildcard pattern
         | SynPat.Wild(_) -> true
@@ -16,15 +16,20 @@ let private checkTupleOfWildcards pattern identifier =
     let constructorString numberOfWildcards =
         let constructorName = identifier |> String.concat "."
         let arguments = Array.create numberOfWildcards "_" |> String.concat ", "
-        constructorName + "(" + arguments + ")"
+        if numberOfWildcards = 1 then
+            sprintf "%s _" constructorName
+        else
+            sprintf "%s(%s)" constructorName arguments
 
     match pattern with
     | SynPat.Tuple(_isStruct, patterns, range) when List.length patterns > 1 && patterns |> List.forall isWildcard ->
         let errorFormat = Resources.GetString("RulesTupleOfWildcardsError")
         let refactorFrom = constructorString (List.length patterns)
-        let refactorTo = (constructorString 1)
+        let refactorTo = constructorString 1
         let error = System.String.Format(errorFormat, refactorFrom, refactorTo)
-        { Range = range; Message = error; SuggestedFix = None; TypeChecks = [] } |> Array.singleton
+        let suggestedFix = lazy(
+            Some { SuggestedFix.FromRange = identifierRange; FromText = fileContents; ToText = refactorTo })
+        { Range = range; Message = error; SuggestedFix = Some suggestedFix; TypeChecks = [] } |> Array.singleton
     | _ -> Array.empty
 
 let private isTupleMemberArgs breadcrumbs tupleRange =
@@ -44,11 +49,11 @@ let private isTupleMemberArgs breadcrumbs tupleRange =
 
 let private runner (args:AstNodeRuleParams) =
     match args.AstNode with
-    | AstNode.Pattern(SynPat.LongIdent(identifier, _, _, SynArgPats.Pats([SynPat.Paren(SynPat.Tuple(_, _, range) as pattern, _)]), _, _)) ->
+    | AstNode.Pattern(SynPat.LongIdent(identifier, _, _, SynArgPats.Pats([SynPat.Paren(SynPat.Tuple(_, _, range) as pattern, _)]), _, identRange)) ->
         let breadcrumbs = args.GetParents 2
         if (not << isTupleMemberArgs breadcrumbs) range then
             let identifier = identifier.Lid |> List.map (fun x -> x.idText)
-            checkTupleOfWildcards pattern identifier
+            checkTupleOfWildcards args.FileContent pattern identifier identRange
         else
             Array.empty
     | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Binding/WildcardNamedWithAsPattern.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Binding/WildcardNamedWithAsPattern.fs
@@ -7,19 +7,22 @@ open FSharp.Compiler.Syntax
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
-let private checkForWildcardNamedWithAsPattern pattern =
+let private checkForWildcardNamedWithAsPattern fileContents pattern =
     match pattern with
-    | SynPat.Named(SynPat.Wild(wildcardRange), _, _, _, range) when wildcardRange <> range ->
+    | SynPat.Named(SynPat.Wild(wildcardRange), identifier, _, _, range) when wildcardRange <> range ->
+        let suggestedFix = 
+            lazy(
+                Some { FromRange = range; FromText = fileContents; ToText = identifier.idText })
         { Range = range
           Message = Resources.GetString("RulesWildcardNamedWithAsPattern")
-          SuggestedFix = None
+          SuggestedFix = Some suggestedFix
           TypeChecks = [] } |> Array.singleton
     | _ -> Array.empty
 
 let private runner (args:AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Pattern(SynPat.Named(SynPat.Wild(_), _, _, _, _) as pattern) ->
-        checkForWildcardNamedWithAsPattern pattern
+        checkForWildcardNamedWithAsPattern args.FileContent pattern
     | _ -> Array.empty
 
 /// Checks if any code uses 'let _ = ...' and suggests to use the ignore function.

--- a/src/FSharpLint.Core/Rules/Conventions/FavourStaticEmptyFields.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourStaticEmptyFields.fs
@@ -24,21 +24,28 @@ let private getStaticEmptyErrorMessage  (range:FSharp.Compiler.Text.Range) (empt
 
     errorMessageKey |> formatError
 
-let private generateError (range:FSharp.Compiler.Text.Range) (emptyLiteralType: EmptyLiteralType) =
+let private generateError (fileContents: string) (range:FSharp.Compiler.Text.Range) (emptyLiteralType: EmptyLiteralType) =
+    let suggestedFix = lazy(
+        let replacementText =
+            match emptyLiteralType with
+            | EmptyStringLiteral -> "String.Empty"
+            | EmptyListLiteral -> "List.Empty"
+            | EmptyArrayLiteral -> "Array.empty"
+        Some({ FromRange = range; FromText = fileContents; ToText = replacementText }))
     { Range = range
       Message = getStaticEmptyErrorMessage range emptyLiteralType
-      SuggestedFix = None
+      SuggestedFix = Some suggestedFix
       TypeChecks = List.Empty }
     |> Array.singleton
 
 let private runner (args: AstNodeRuleParams) =
     match args.AstNode with
     | AstNode.Expression(SynExpr.Const (SynConst.String ("", _, range), _)) -> 
-        generateError range EmptyStringLiteral
+        generateError args.FileContent range EmptyStringLiteral
     | AstNode.Expression(SynExpr.ArrayOrList (isArray, [], range)) ->
         let emptyLiteralType =
             if isArray then EmptyArrayLiteral else EmptyListLiteral
-        generateError range emptyLiteralType
+        generateError args.FileContent range emptyLiteralType
     | _ -> Array.empty
 
 

--- a/src/FSharpLint.Core/Rules/Conventions/FunctionReimplementation/CanBeReplacedWithComposition.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FunctionReimplementation/CanBeReplacedWithComposition.fs
@@ -7,11 +7,11 @@ open FSharp.Compiler.Syntax
 open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
 
-let private validateLambdaCannotBeReplacedWithComposition _ lambda range =
-    let canBeReplacedWithFunctionComposition expression =
+let private validateLambdaCannotBeReplacedWithComposition fileContents _ lambda range =
+    let tryReplaceWithFunctionComposition expression =
         let getLastElement = List.rev >> List.head
 
-        let rec lambdaArgumentIsLastApplicationInFunctionCalls expression (lambdaArgument:Ident) numFunctionCalls =
+        let rec lambdaArgumentIsLastApplicationInFunctionCalls expression (lambdaArgument:Ident) (calledFunctionIdents: List<string>) =
             let rec appliedValuesAreConstants appliedValues =
                 match appliedValues with
                 | (SynExpr.Const(_)| SynExpr.Null(_))::rest -> appliedValuesAreConstants rest
@@ -21,34 +21,56 @@ let private validateLambdaCannotBeReplacedWithComposition _ lambda range =
             match AstNode.Expression expression with
             | FuncApp(exprs, _) ->
                 match List.map removeParens exprs with
-                | (SynExpr.Ident(_) | SynExpr.LongIdent(_))::appliedValues
+                | (ExpressionUtilities.Identifier(idents, _))::appliedValues
                         when appliedValuesAreConstants appliedValues ->
-
+                    
+                    let funcName = String.Join(".", idents)
+                    let funcStringParts = 
+                        Seq.append
+                            (Seq.singleton funcName)
+                            (appliedValues 
+                                |> Seq.take (appliedValues.Length - 1) 
+                                |> Seq.choose (fun value -> ExpressionUtilities.tryFindTextOfRange value.Range fileContents))
+                    let funcString = String.Join(" ", funcStringParts)
+                    
                     match getLastElement appliedValues with
-                    | SynExpr.Ident(lastArgument) when numFunctionCalls > 1 ->
-                        lastArgument.idText = lambdaArgument.idText
+                    | SynExpr.Ident(lastArgument) when calledFunctionIdents.Length > 1 ->
+                        if lastArgument.idText = lambdaArgument.idText then
+                            funcString :: calledFunctionIdents
+                        else
+                            []
                     | SynExpr.App(_, false, _, _, _) as nextFunction ->
-                        lambdaArgumentIsLastApplicationInFunctionCalls nextFunction lambdaArgument (numFunctionCalls + 1)
-                    | _ -> false
-                | _ -> false
-            | _ -> false
+                        lambdaArgumentIsLastApplicationInFunctionCalls 
+                            nextFunction 
+                            lambdaArgument 
+                            (funcString :: calledFunctionIdents)
+                    | _ -> []
+                | _ -> []
+            | _ -> []
 
         match lambda.Arguments with
         | [singleParameter] ->
-            Helper.FunctionReimplementation.getLambdaParamIdent singleParameter
-            |> Option.exists (fun paramIdent -> lambdaArgumentIsLastApplicationInFunctionCalls expression paramIdent 1)
-        | _ -> false
+            match Helper.FunctionReimplementation.getLambdaParamIdent singleParameter with
+            | Some paramIdent -> 
+                match lambdaArgumentIsLastApplicationInFunctionCalls expression paramIdent [] with
+                | [] -> None
+                | funcStrings -> Some funcStrings
+            | None -> None
+        | _ -> None
 
-    if canBeReplacedWithFunctionComposition lambda.Body then
+    match tryReplaceWithFunctionComposition lambda.Body with
+    | None -> Array.empty
+    | Some funcStrings ->
+        let suggestedFix =
+            lazy(
+                Some { FromRange = range; FromText = fileContents; ToText = String.Join(" >> ", funcStrings) })
         { Range = range
           Message = Resources.GetString("RulesCanBeReplacedWithComposition")
-          SuggestedFix = None
+          SuggestedFix = Some suggestedFix
           TypeChecks = [] } |> Array.singleton
-    else
-        Array.empty
 
 let runner (args:AstNodeRuleParams) =
-    Helper.FunctionReimplementation.checkLambda args validateLambdaCannotBeReplacedWithComposition
+    Helper.FunctionReimplementation.checkLambda args (validateLambdaCannotBeReplacedWithComposition args.FileContent)
 
 let rule =
     { Name = "CanBeReplacedWithComposition"

--- a/tests/FSharpLint.Core.Tests/Rules/Binding/TupleOfWildcards.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Binding/TupleOfWildcards.fs
@@ -20,6 +20,38 @@ match Persian(1, 3) with
         Assert.IsTrue(this.ErrorExistsAt(7, 14))
 
     [<Test>]
+    member this.``Suggested fix for tuple of wildcards should be single wildcard``() = 
+        let source = """
+match cat with
+| Persian(_, _) -> ()"""
+
+        let expected = """
+match cat with
+| Persian _ -> ()"""
+
+        this.Parse source
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
+    member this.``Suggested fix for tuple of wildcards in nested pattern should be single wildcard``() = 
+        let source = """
+match maybeCat with
+| Some(Persian(_, _)) -> ()"""
+
+        let expected = """
+match maybeCat with
+| Some(Persian _) -> ()"""
+
+        this.Parse source
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
     member this.``Method's parameter list of wildcards should not be treated as tuple of wildcards.``() = 
         this.Parse """
 module Program

--- a/tests/FSharpLint.Core.Tests/Rules/Binding/WildcardNamedWithAsPattern.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Binding/WildcardNamedWithAsPattern.fs
@@ -9,13 +9,25 @@ type TestBindingWildcardNamedWithAsPattern() =
 
     [<Test>]
     member this.WildcardNamedWithAsPattern() =
-        this.Parse """
+        let source = """
 module Program
 
 match [] with
     | _ as x -> ()"""
 
+        let expected = """
+module Program
+
+match [] with
+    | x -> ()"""
+        
+        this.Parse source
+
         Assert.IsTrue(this.ErrorExistsAt(5, 6))
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
 
     [<Test>]
     member this.NamedPattern() =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
@@ -94,3 +94,20 @@ let someFunc someParam =
 """
 
         Assert.IsFalse this.ErrorsExist
+
+    [<Test>]
+    member this.``Suggest not using pipe operator if it's used once``() =
+        let source = """
+let someFunc someParam =
+    someParam
+    |> someOtherFunc
+"""
+        let expected = """
+let someFunc someParam =
+    someOtherFunc someParam
+"""
+        
+        this.Parse source
+        let fixedSource = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, fixedSource)

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourStaticEmptyFields.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourStaticEmptyFields.fs
@@ -126,3 +126,45 @@ match foo with
 | head::_ -> false"""
 
         Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.FavourStaticEmptyFieldsSuggestedFixForString() =
+        let source = "let foo = \"\""
+
+        let expected = "let foo = String.Empty"
+        
+        this.Parse source
+
+        Assert.IsTrue this.ErrorsExist
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
+    member this.FavourStaticEmptyFieldsSuggestedFixForList() =
+        let source = "let foo = []"
+
+        let expected = "let foo = List.Empty"
+        
+        this.Parse source
+
+        Assert.IsTrue this.ErrorsExist
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
+    member this.FavourStaticEmptyFieldsSuggestedFixForArray() =
+        let source = "let foo = [||]"
+
+        let expected = "let foo = Array.empty"
+        
+        this.Parse source
+
+        Assert.IsTrue this.ErrorsExist
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FunctionReimplementation.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FunctionReimplementation.fs
@@ -201,6 +201,66 @@ let f = fun x -> x |> tan 0 |> cos |> tan
         Assert.IsTrue(this.ErrorExistsAt(4, 8))
 
     [<Test>]
+    member this.``Test quick fix for nested function calls that can be replaced with composition``() =
+        let source = """
+module Program
+
+let f = fun x -> sin(cos(tan x))
+"""
+        
+        let expected = """
+module Program
+
+let f = tan >> cos >> sin
+"""
+        
+        this.Parse source
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
+    member this.``Test quick fix for piped function calls that can be replaced with composition``() =
+        let source = """
+module Program
+
+let f = fun x -> x |> tan |> cos |> sin
+"""
+        
+        let expected = """
+module Program
+
+let f = tan >> cos >> sin
+"""
+        
+        this.Parse source
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
+    member this.``Test quick fix for piped function calls with partially applied functions that can be replaced with composition``() =
+        let source = """
+module Program
+
+let f = fun x -> x |> min 0.0 |> cos |> tan
+"""
+        
+        let expected = """
+module Program
+
+let f = min 0.0 >> cos >> tan
+"""
+        
+        this.Parse source
+
+        let result = this.ApplyQuickFix source
+
+        Assert.AreEqual(expected, result)
+
+    [<Test>]
     member this.``Applying closed over identifier in chain will not issue composition suggestion``() =
         this.Parse """
 module Program


### PR DESCRIPTION
Add quickfix suggestions for following rules:

- Rule 35 (CanBeReplacedWithComposition)
- Rule 56 (WildcardNamedWithAsPattern)
- Rule 58 (TupleOfWildcards)
- Rule 76 (FavourStaticEmptyFields)
- Rule 77 (AvoidSinglePipeOperator)