### PR TITLE
build.fsx,RELEASE.md: don't push prereleases for relNotes commits

### DIFF
--- a/.github/workflows/build+test+publish.yml
+++ b/.github/workflows/build+test+publish.yml
@@ -64,7 +64,6 @@ jobs:
       env:
         nuget-key: ${{ secrets.NUGET_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name == 'push' && env.nuget-key != null
       run: dotnet fake build -t Push
     - name: Create Release (if tag)
       if: startsWith(github.ref, 'refs/tags/')

--- a/build.fsx
+++ b/build.fsx
@@ -45,7 +45,12 @@ let exec cmd args dir =
     |> Proc.run
     |> ignore
 
-let getBuildParam = Environment.environVar
+let getBuildParam var =
+    let value = Environment.environVar var
+    if String.IsNullOrWhiteSpace value then
+        None
+    else
+        Some value
 let DoNothing = ignore
 
 // --------------------------------------------------------------------------------------
@@ -163,11 +168,29 @@ Target.create "Pack" (fun _ ->
 )
 
 Target.create "Push" (fun _ ->
-    let key =
-        match getBuildParam "nuget-key" with
-        | s when not (isNullOrWhiteSpace s) -> s
-        | _ -> UserInput.getUserPassword "NuGet Key: "
-    Paket.push (fun p -> { p with WorkingDir = nugetDir; ApiKey = key; ToolType = ToolType.CreateLocalTool() }))
+    let push key =
+        Paket.push (fun p -> { p with WorkingDir = nugetDir; ApiKey = key; ToolType = ToolType.CreateLocalTool() })
+
+    let key = getBuildParam "nuget-key"
+    match getBuildParam "GITHUB_EVENT_NAME" with
+    | None ->
+        match key with
+        | None ->
+            let key = UserInput.getUserPassword "NuGet Key: "
+            push key
+        | Some key ->
+            push key
+
+    | Some "push" ->
+        match key with
+        | None ->
+            Console.WriteLine "No nuget-key env var found, skipping..."
+        | Some key ->
+            push key
+    | _ ->
+        Console.WriteLine "Github event name not 'push', skipping..."
+
+)
 
 
 Target.create "SelfCheck" (fun _ ->


### PR DESCRIPTION
The way we had setup the prerelease push was making unnecessary prerelease packages for the same commit that ends up being mapped to a release. But if we push the tag and the branch at the same time, and check the commit with 'git describe' then we can detect the situation and avert it.