### PR TITLE
Fix bugs in NoPartialFunctions rule

### DIFF
--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
@@ -63,6 +63,19 @@ module Program =
         this.AssertErrorWithMessageExists("Consider using pattern matching instead of partial function/method 'Option.Value'.")
 
     [<Test>]
+    member this.``No error for calling Value on ref type (regression)``() =
+        this.Parse("""
+namespace Foo
+module Program =
+    let foo = None
+    let bar = ref 0
+
+    let printFoo() =
+        System.Console.WriteLine (bar.Value.ToString())""")
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
     member this.``Error for Option.Value (List.tryHead test case)``() =
         this.Parse("""
 namespace Foo

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
@@ -63,6 +63,20 @@ module Program =
         this.AssertErrorWithMessageExists("Consider using pattern matching instead of partial function/method 'Option.Value'.")
 
     [<Test>]
+    member this.``Error for Option.Value (List.tryHead test case)``() =
+        this.Parse("""
+namespace Foo
+module Program =
+    let foo = []
+
+    let printFoo() =
+        System.Console.WriteLine ((List.tryHead foo).Value.ToString())""")
+
+        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue(this.ErrorExistsAt(7, 34))
+        this.AssertErrorWithMessageExists("Consider using pattern matching instead of partial function/method 'Option.Value'.")
+
+    [<Test>]
     member this.``No error for value property in DU``() =
         this.Parse("
 namespace Foo


### PR DESCRIPTION
Fix bugs in NoPartialFunctions rule:
- false negative when instance member is called on arbitrary expression, not just dotted identifier.
- false positive when `Value` instance method is called on value that is not `Option`, but another `Option` value exists in scope.

Added tests for these cases.