### PR TITLE
Core: fix in getPatternIdents

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NamingHelper.fs
@@ -362,7 +362,10 @@ let rec getPatternIdents<'T> (accessibility:AccessControlLevel) (getIdents:GetId
     | SynPat.Wild(_)
     | SynPat.OptionalVal(_)
     | SynPat.DeprecatedCharRange(_) | SynPat.InstanceMember(_) | SynPat.FromParseError(_) -> Array.empty
-    | SynPat.As(_) -> failwith "Not implemented"
+    | SynPat.As(lhsPat, rhsPat, _) -> 
+        Array.append
+            (getPatternIdents accessibility getIdents false lhsPat)
+            (getPatternIdents accessibility getIdents false rhsPat)
 
 let rec identFromSimplePat = function
     | SynSimplePat.Id(ident, _, _, _, _, _) -> Some ident

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
@@ -96,3 +96,11 @@ let foo _x = 0
 
         this.Parse source
         Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+    [<Test>]
+    member this.``As pattern is processed correctly (GetPatternIdents regression)``() =
+        this.Parse """
+let foo ((x, y) as bar_coord) = bar_coord
+"""
+        
+        Assert.IsTrue this.ErrorsExist


### PR DESCRIPTION
Fix in Helper.Naming.getPatternIdents - implemented SynPat.As case handling.

Fixes #670