### PR TITLE
Pipe operator: fix range

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/AvoidSinglePipeOperator.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/AvoidSinglePipeOperator.fs
@@ -23,7 +23,7 @@ let runner (args: AstNodeRuleParams) =
             match synExpr with
             | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, _argExpr, _range) ->
                 match funcExpr with
-                | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, argExpr, range) ->
+                | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, argExpr, _range) ->
                     match funcExpr with
                     | ExpressionUtilities.Identifier([ ident ], _) ->
                         if ident.idText = "op_PipeRight" then
@@ -31,7 +31,7 @@ let runner (args: AstNodeRuleParams) =
                             | SynExpr.App(_exprAtomicFlag, _isInfix, _funcExpr, _argExpr, _range) ->
                                 Array.empty 
                             | _ ->
-                                errors range
+                                errors ident.idRange
                         else
                             Array.empty
                     | _ ->

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/AvoidSinglePipeOperator.fs
@@ -16,7 +16,7 @@ let someFunc someParam =
     |> someOtherFunc
 """
 
-        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue <| this.ErrorExistsAt(4, 4)
 
     [<Test>]
     member this.``Use pipe operator twice``() =
@@ -38,7 +38,7 @@ module MyModule =
         |> someOtherFunc
 """
 
-        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue <| this.ErrorExistsAt(5, 8)
 
     [<Test>]
     member this.``Use pipe operator twice in module``() =
@@ -61,7 +61,7 @@ type CustomerName(firstName) =
         |> someOtherFunc
         """
 
-        Assert.IsTrue this.ErrorsExist
+        Assert.IsTrue <| this.ErrorExistsAt(5, 8)
 
     [<Test>]
     member this.``Use pipe operator twice in type``() =


### PR DESCRIPTION
Fix range in AvoidSinglePipeOperator rule. Make tests for this rule check range not just existence of error.