### PR TITLE
Core.Application: make inline source filepath less confusing

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -519,7 +519,7 @@ module Lint =
                 { ParseFile.Text = parsedFileInfo.Source
                   ParseFile.Ast = parsedFileInfo.Ast
                   ParseFile.TypeCheckResults = parsedFileInfo.TypeCheckResults
-                  ParseFile.File = "/home/user/Dog.Test.fsx" }
+                  ParseFile.File = "<inline source>" }
 
             lint lintInformation parsedFileInfo
 


### PR DESCRIPTION
When linting source provided directly as command line argument, change displayed file name to `"<inline source>"` so it's clear that inline source is being linted, rather than confusing `"/home/user/Dog.Test.fsx"`.

Closes https://github.com/fsprojects/FSharpLint/issues/674