### PR TITLE
Add FavourNonMutablePropertyInitialization rule

### DIFF
--- a/docs/content/how-tos/rule-configuration.md
+++ b/docs/content/how-tos/rule-configuration.md
@@ -124,3 +124,4 @@ The following rules can be specified for linting.
 - [NestedFunctionNames (FL0081)](rules/FL0081.html)
 - [UsedUnderscorePrefixedElements (FL0082)](rules/FL0082.html)
 - [UnneededRecKeyword (FL0083)](rules/FL0083.html)
+- [FavourNonMutablePropertyInitialization (FL0084)](rules/FL0084.html)

--- a/docs/content/how-tos/rules/FL0084.md
+++ b/docs/content/how-tos/rules/FL0084.md
@@ -1,0 +1,29 @@
+---
+title: FL0084
+category: how-to
+hide_menu: true
+---
+
+# FavourNonMutablePropertyInitialization (FL0084)
+
+*Introduced in `0.24.0`*
+
+## Cause
+
+Use of mutation to initialize properties with values.
+
+## Rationale
+
+There's no need to use mutation to initialize properties with values because F# has specific syntax for this kind of intitialization.
+Both approaches will compile to the same IL but non-mutable code doesn't look unsafe because it prevents the use of the `<-` operator.
+
+## How To Fix
+
+Replace all occurrences of mutable property initialization with non mutable property initialization.
+Example: `Cookie(Domain = "example.com")` instead of `let c = Cookie(); c.Domain <- "example.com"`
+
+## Rule Settings
+
+    {
+        "FavourNonMutablePropertyInitialization": { "enabled": false }
+    }

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -318,6 +318,7 @@ type ConventionsConfig =
       favourStaticEmptyFields:EnabledConfig option
       asyncExceptionWithoutReturn:EnabledConfig option
       unneededRecKeyword:EnabledConfig option
+      favourNonMutablePropertyInitialization:EnabledConfig option
       nestedStatements:RuleConfig<NestedStatements.Config> option
       cyclomaticComplexity:RuleConfig<CyclomaticComplexity.Config> option
       reimplementsFunction:EnabledConfig option
@@ -338,6 +339,7 @@ with
             this.recursiveAsyncFunction |> Option.bind (constructRuleIfEnabled RecursiveAsyncFunction.rule) |> Option.toArray
             this.avoidTooShortNames |> Option.bind (constructRuleIfEnabled AvoidTooShortNames.rule) |> Option.toArray           
             this.redundantNewKeyword |> Option.bind (constructRuleIfEnabled RedundantNewKeyword.rule) |> Option.toArray
+            this.favourNonMutablePropertyInitialization |> Option.bind (constructRuleIfEnabled FavourNonMutablePropertyInitialization.rule) |> Option.toArray
             this.favourReRaise |> Option.bind (constructRuleIfEnabled FavourReRaise.rule) |> Option.toArray
             this.favourStaticEmptyFields |> Option.bind (constructRuleIfEnabled FavourStaticEmptyFields.rule) |> Option.toArray
             this.asyncExceptionWithoutReturn |> Option.bind (constructRuleIfEnabled AsyncExceptionWithoutReturn.rule) |> Option.toArray
@@ -412,6 +414,7 @@ type Configuration =
       RecursiveAsyncFunction:EnabledConfig option
       AvoidTooShortNames:EnabledConfig option
       RedundantNewKeyword:EnabledConfig option
+      FavourNonMutablePropertyInitialization:EnabledConfig option
       FavourReRaise:EnabledConfig option
       FavourStaticEmptyFields:EnabledConfig option
       AsyncExceptionWithoutReturn:EnabledConfig option
@@ -501,6 +504,7 @@ with
         RecursiveAsyncFunction = None
         AvoidTooShortNames = None
         RedundantNewKeyword = None
+        FavourNonMutablePropertyInitialization = None
         FavourReRaise = None
         FavourStaticEmptyFields = None
         AsyncExceptionWithoutReturn = None
@@ -653,6 +657,7 @@ let flattenConfig (config:Configuration) =
             config.RecursiveAsyncFunction |> Option.bind (constructRuleIfEnabled RecursiveAsyncFunction.rule)
             config.AvoidTooShortNames |> Option.bind (constructRuleIfEnabled AvoidTooShortNames.rule)
             config.RedundantNewKeyword |> Option.bind (constructRuleIfEnabled RedundantNewKeyword.rule)
+            config.FavourNonMutablePropertyInitialization |> Option.bind (constructRuleIfEnabled FavourNonMutablePropertyInitialization.rule)
             config.FavourReRaise |> Option.bind (constructRuleIfEnabled FavourReRaise.rule)
             config.FavourStaticEmptyFields |> Option.bind (constructRuleIfEnabled FavourStaticEmptyFields.rule)
             config.AsyncExceptionWithoutReturn |> Option.bind (constructRuleIfEnabled AsyncExceptionWithoutReturn.rule)

--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -48,10 +48,7 @@ module FSharpJsonConverter =
         |]
 
     let serializerSettings =
-        let settings = JsonSerializerSettings()
-        settings.NullValueHandling <- NullValueHandling.Ignore
-        settings.Converters <- converters
-        settings
+        JsonSerializerSettings(NullValueHandling = NullValueHandling.Ignore, Converters = converters)
 
 module IgnoreFiles =
 

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -261,17 +261,18 @@ module Lint =
         ReachedEnd(fileInfo.File, fileWarnings |> Seq.toList) |> lintInfo.ReportLinterProgress
 
     let private runProcess (workingDir:string) (exePath:string) (args:string) =
-        let psi = System.Diagnostics.ProcessStartInfo()
-        psi.FileName <- exePath
-        psi.WorkingDirectory <- workingDir
-        psi.RedirectStandardOutput <- true
-        psi.RedirectStandardError <- true
-        psi.Arguments <- args
-        psi.CreateNoWindow <- true
-        psi.UseShellExecute <- false
+        let psi = 
+            System.Diagnostics.ProcessStartInfo(
+                FileName = exePath,
+                WorkingDirectory = workingDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                Arguments = args,
+                CreateNoWindow = true,
+                UseShellExecute = false
+            )
 
-        use p = new System.Diagnostics.Process()
-        p.StartInfo <- psi
+        use p = new System.Diagnostics.Process(StartInfo = psi)
         let sbOut = System.Text.StringBuilder()
         p.OutputDataReceived.Add(fun ea -> sbOut.AppendLine(ea.Data) |> ignore)
         let sbErr = System.Text.StringBuilder()

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
     <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
     <Compile Include="Rules\Conventions\UsedUnderscorePrefixedElements.fs" />
+    <Compile Include="Rules\Conventions\FavourNonMutablePropertyInitialization.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithTooManyArgumentsHelper.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\FailwithWithSingleArgument.fs" />
     <Compile Include="Rules\Conventions\RaiseWithTooManyArguments\RaiseWithSingleArgument.fs" />

--- a/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -72,7 +72,8 @@ let traverseSynModule (declarations: List<SynModuleDecl>) (identifiers: List<str
         | SynModuleDecl.Let(_, bindings, _)::rest ->
             match bindings with
             | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), app, _), _, _), _, _, _)::nrest
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest ->
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest 
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), app, _), _, _), _, _, _)::nrest ->
                 let instanceMethodCall = extraInstanceMethod app instancesWithMethodCall
                 let instances = extraFromBindings bindings classInstances
                 match List.tryLast identifiers with

--- a/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -1,9 +1,103 @@
 module FSharpLint.Rules.FavourNonMutablePropertyInitialization
 
+open FSharpLint.Framework
+open FSharpLint.Framework.Suggestion
+open FSharp.Compiler.Syntax
+open FSharpLint.Framework.Ast
 open FSharpLint.Framework.Rules
+open System
 
-let runner _args =
-    failwith "Not implemented yet"
+let private getWarningDetails (ident: Ident) =
+    let formatError errorName =
+        String.Format(Resources.GetString errorName, ident.idText)
+
+    "RulesFavourNonMutablePropertyInitializationError"
+    |> formatError
+    |> Array.singleton
+    |> Array.map (fun message ->
+        { Range = ident.idRange
+          Message = message
+          SuggestedFix = None
+          TypeChecks = List.Empty })
+
+let traverseSynModule (declarations: List<SynModuleDecl>) (identifiers: List<string>) =
+    let containsInstance (instance: string) (instances: List<string>) =
+        List.exists (fun elem -> elem = instance) instances
+
+    let extraInstanceMethod (app:SynExpr) (instanceMethodCalls: List<string>) =
+        match app with
+        | SynExpr.App(_, _, expression, _, _) ->
+            match expression with
+            | SynExpr.LongIdent(_, SynLongIdent(identifiers, _, _), _, _) ->
+                match List.tryLast identifiers with
+                | Some _ ->
+                    identifiers.[0].idText::instanceMethodCalls
+                | _ -> instanceMethodCalls
+            | _ -> instanceMethodCalls
+        | _ -> instanceMethodCalls
+
+    let rec extraFromBindings (bindings: List<SynBinding>) (classInstances: List<string>) =
+        match bindings with
+        | SynBinding(_, _, _, _, _, _, _, SynPat.Named(SynIdent(ident, _), _, _, _), _, _expression, _, _, _)::rest ->
+            extraFromBindings rest (ident.idText::classInstances)
+        | _ -> classInstances
+
+    let rec traverse (declarations: List<SynModuleDecl>) (classInstances: List<string>) (instancesWithMethodCall: List<string>) =
+        match declarations with
+        | SynModuleDecl.Expr(expression, _)::rest ->
+            match expression with
+            | SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _) ->
+                match List.tryLast identifiers with
+                | None ->
+                    Array.empty
+                | Some last ->
+                    if containsInstance identifiers.[0].idText classInstances then
+                        if not (containsInstance identifiers.[0].idText instancesWithMethodCall) then
+                            getWarningDetails last
+                        else
+                            Array.empty
+                    else
+                        Array.empty
+            | SynExpr.App(_, _, expression, _, _) ->
+                match expression with
+                | SynExpr.LongIdent(_, SynLongIdent(identifiers, _, _), _, _) ->
+                    match List.tryLast identifiers with
+                    | Some _ ->
+                        traverse rest classInstances (identifiers.[0].idText::instancesWithMethodCall)
+                    | _ -> traverse rest classInstances instancesWithMethodCall
+                | _ -> traverse rest classInstances instancesWithMethodCall
+            | _ -> Array.empty
+        | SynModuleDecl.NestedModule(_componentInfo, _, moduleDeclarations, _, _, _)::_ ->
+            traverse moduleDeclarations classInstances instancesWithMethodCall
+        | SynModuleDecl.Let(_, bindings, _)::rest ->
+            match bindings with
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), app, _), _, _), _, _, _)::nrest
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest ->
+                let instanceMethodCall = extraInstanceMethod app instancesWithMethodCall
+                let instances = extraFromBindings bindings classInstances
+                match List.tryLast identifiers with
+                | None ->
+                    traverse rest (extraFromBindings nrest classInstances) instancesWithMethodCall
+                | Some last ->
+                    if containsInstance identifiers.[0].idText instances then
+                        if not (containsInstance identifiers.[0].idText instanceMethodCall) then
+                            getWarningDetails last
+                        else
+                            Array.empty
+                    else
+                        traverse rest (extraFromBindings nrest classInstances) instancesWithMethodCall
+            | _ -> traverse rest (extraFromBindings bindings classInstances) instancesWithMethodCall
+        | _::rest -> traverse rest classInstances instancesWithMethodCall
+        | [] -> Array.empty
+
+
+    traverse declarations identifiers List.Empty
+
+let runner args =
+    match args.AstNode with
+    | ModuleOrNamespace(SynModuleOrNamespace(_, _, _, moduleDeclarations, _, _, _, _, _)) ->
+        traverseSynModule moduleDeclarations List.Empty
+    | _ -> Array.empty
 
 let rule =
     { Name = "FavourNonMutablePropertyInitialization"

--- a/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -1,0 +1,12 @@
+module FSharpLint.Rules.FavourNonMutablePropertyInitialization
+
+open FSharpLint.Framework.Rules
+
+let runner _args =
+    failwith "Not implemented yet"
+
+let rule =
+    { Name = "FavourNonMutablePropertyInitialization"
+      Identifier = Identifiers.FavourNonMutablePropertyInitialization
+      RuleConfig = { AstNodeRuleConfig.Runner = runner; Cleanup = ignore } }
+    |> AstNodeRule

--- a/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -20,97 +20,69 @@ let private getWarningDetails (ident: Ident) =
           SuggestedFix = None
           TypeChecks = List.Empty })
 
-let traverseSynModule (declarations: List<SynModuleDecl>) (identifiers: List<string>) =
-    let containsInstance (instance: string) (instances: List<string>) =
-        List.exists (fun elem -> elem = instance) instances
-
-    let extraInstanceMethod (app:SynExpr) (instanceMethodCalls: List<string>) =
-        match app with
-        | SynExpr.App(_, _, expression, _, _) ->
-            match expression with
-            | SynExpr.LongIdent(_, SynLongIdent(identifiers, _, _), _, _) ->
-                match List.tryLast identifiers with
-                | Some _ ->
-                    identifiers.[0].idText::instanceMethodCalls
-                | _ -> instanceMethodCalls
+let private extraInstanceMethod (app:SynExpr) (instanceMethodCalls: List<string>) =
+    match app with
+    | SynExpr.App(_, _, expression, _, _) ->
+        match expression with
+        | SynExpr.LongIdent(_, SynLongIdent(identifiers, _, _), _, _) ->
+            match List.tryLast identifiers with
+            | Some _ ->
+                identifiers.[0].idText::instanceMethodCalls
             | _ -> instanceMethodCalls
         | _ -> instanceMethodCalls
+    | _ -> instanceMethodCalls
 
-    let rec extraFromBindings (bindings: List<SynBinding>) (classInstances: List<string>) =
-        match bindings with
-        | SynBinding(_, _, _, _, _, _, _, SynPat.Named(SynIdent(ident, _), _, _, _), _, _expression, _, _, _)::rest ->
-            extraFromBindings rest (ident.idText::classInstances)
-        | _ -> classInstances
+let rec private extraFromBindings (bindings: List<SynBinding>) (classInstances: List<string>) =
+    match bindings with
+    | SynBinding(_, _, _, _, _, _, _, SynPat.Named(SynIdent(ident, _), _, _, _), _, _expression, _, _, _)::rest ->
+        extraFromBindings rest (ident.idText::classInstances)
+    | _ -> classInstances
 
-    let rec traverse (declarations: List<SynModuleDecl>) (classInstances: List<string>) (instancesWithMethodCall: List<string>) =
-        match declarations with
-        | SynModuleDecl.Expr(expression, _)::rest ->
-            match expression with
-            | SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _) ->
-                match List.tryLast identifiers with
-                | None ->
-                    Array.empty
-                | Some last ->
-                    if containsInstance identifiers.[0].idText classInstances then
-                        if not (containsInstance identifiers.[0].idText instancesWithMethodCall) then
-                            getWarningDetails last
-                        else
-                            Array.empty
-                    else
-                        Array.empty
-            | SynExpr.App(_, _, expression, _, _) ->
-                match expression with
-                | SynExpr.LongIdent(_, SynLongIdent(identifiers, _, _), _, _) ->
-                    match List.tryLast identifiers with
-                    | Some _ ->
-                        traverse rest classInstances (identifiers.[0].idText::instancesWithMethodCall)
-                    | _ -> traverse rest classInstances instancesWithMethodCall
-                | _ -> traverse rest classInstances instancesWithMethodCall
-            | _ -> Array.empty
-        | SynModuleDecl.NestedModule(_componentInfo, _, moduleDeclarations, _, _, _)::_ ->
-            traverse moduleDeclarations classInstances instancesWithMethodCall
-        | SynModuleDecl.Let(_, bindings, _)::rest ->
-            let issueWargnings (bindings: List<SynBinding>) (identifiers: LongIdent) (restOfBindings: List<SynBinding>) (maybeApp: Option<SynExpr>) =
-                let instanceMethodCall = 
-                    match maybeApp with
-                    | Some app -> extraInstanceMethod app instancesWithMethodCall
-                    | None -> instancesWithMethodCall
-                let instances = extraFromBindings bindings classInstances
-                match List.tryLast identifiers with
-                | None ->
-                    traverse rest (extraFromBindings restOfBindings classInstances) instancesWithMethodCall
-                | Some last ->
-                    if containsInstance identifiers.[0].idText instances then
-                        if not (containsInstance identifiers.[0].idText instanceMethodCall) then
-                            getWarningDetails last
-                        else
-                            Array.empty
-                    else
-                        traverse rest (extraFromBindings restOfBindings classInstances) instancesWithMethodCall
+let rec private processLetBinding (instanceNames: Set<string>) (body: SynExpr) : array<WarningDetails> =
+    match body with
+    | SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _) ->
+        match identifiers with
+        | [instanceIdent; propertyIdent] when Set.contains instanceIdent.idText instanceNames ->
+            getWarningDetails propertyIdent
+        | _ -> Array.empty
+    | SynExpr.Sequential(_, _, expr1, expr2, _) ->
+        let instanceNames =
+            Set.difference
+                instanceNames
+                (extraInstanceMethod expr1 List.empty |> Set.ofList)
+        Array.append
+            (processLetBinding instanceNames expr1)
+            (processLetBinding instanceNames expr2)
+    | _ -> [||]
 
-            match bindings with
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), app, _), _, _), _, _, _)::nrest
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest when identifiers.Length > 1 ->
-                match app with
-                | SynExpr.LongIdentSet(SynLongIdent(headIdentifiers, _, _), _, _) when headIdentifiers.Length > 1 ->
-                    Array.append
-                        (issueWargnings bindings headIdentifiers List.empty None)
-                        (issueWargnings bindings identifiers nrest None)
-                | _ ->
-                    issueWargnings bindings identifiers nrest (Some app)
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _, _), _, _), _, _, _)::nrest when identifiers.Length > 1 ->
-                issueWargnings bindings identifiers nrest None
-            | _ -> traverse rest (extraFromBindings bindings classInstances) instancesWithMethodCall
-        | _::rest -> traverse rest classInstances instancesWithMethodCall
-        | [] -> Array.empty
-
-
-    traverse declarations identifiers List.Empty
+and processExpression (expression: SynExpr) : array<WarningDetails> =
+    match expression with
+    | SynExpr.LetOrUse(_, _, bindings, body, _, _) ->
+        let instanceNames = extraFromBindings bindings [] |> Set.ofList
+        processLetBinding instanceNames body
+    | SynExpr.Sequential(_, _, expr1, expr2, _) ->
+        Array.append
+            (processExpression expr1)
+            (processExpression expr2)
+    | _ -> Array.empty
 
 let runner args =
     match args.AstNode with
-    | ModuleOrNamespace(SynModuleOrNamespace(_, _, _, moduleDeclarations, _, _, _, _, _)) ->
-        traverseSynModule moduleDeclarations List.Empty
+    | Binding(SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, body, _, _), _, _, _)) ->
+        let instanceNames = extraFromBindings bindings [] |> Set.ofList
+        processLetBinding instanceNames body
+    | Match(SynMatchClause(_, _, expr, _, _, _)) ->
+        processExpression expr
+    | Lambda(lambda, _) ->
+        processExpression lambda.Body
+    | Expression(SynExpr.TryWith(tryExpr, _, _, _, _, _)) ->
+        processExpression tryExpr
+    | Expression(SynExpr.TryFinally(tryExpr, finallyExpr, _, _, _, _)) ->
+        Array.append
+            (processExpression tryExpr)
+            (processExpression finallyExpr)
+    | Expression(SynExpr.ComputationExpr(_, expr, _)) ->
+        processExpression expr
     | _ -> Array.empty
 
 let rule =

--- a/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -70,15 +70,15 @@ let traverseSynModule (declarations: List<SynModuleDecl>) (identifiers: List<str
         | SynModuleDecl.NestedModule(_componentInfo, _, moduleDeclarations, _, _, _)::_ ->
             traverse moduleDeclarations classInstances instancesWithMethodCall
         | SynModuleDecl.Let(_, bindings, _)::rest ->
-            match bindings with
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), app, _), _, _), _, _, _)::nrest
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest 
-            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), app, _), _, _), _, _, _)::nrest ->
-                let instanceMethodCall = extraInstanceMethod app instancesWithMethodCall
+            let issueWargnings (bindings: List<SynBinding>) (identifiers: LongIdent) (restOfBindings: List<SynBinding>) (maybeApp: Option<SynExpr>) =
+                let instanceMethodCall = 
+                    match maybeApp with
+                    | Some app -> extraInstanceMethod app instancesWithMethodCall
+                    | None -> instancesWithMethodCall
                 let instances = extraFromBindings bindings classInstances
                 match List.tryLast identifiers with
                 | None ->
-                    traverse rest (extraFromBindings nrest classInstances) instancesWithMethodCall
+                    traverse rest (extraFromBindings restOfBindings classInstances) instancesWithMethodCall
                 | Some last ->
                     if containsInstance identifiers.[0].idText instances then
                         if not (containsInstance identifiers.[0].idText instanceMethodCall) then
@@ -86,7 +86,20 @@ let traverseSynModule (declarations: List<SynModuleDecl>) (identifiers: List<str
                         else
                             Array.empty
                     else
-                        traverse rest (extraFromBindings nrest classInstances) instancesWithMethodCall
+                        traverse rest (extraFromBindings restOfBindings classInstances) instancesWithMethodCall
+
+            match bindings with
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), app, _), _, _), _, _, _)::nrest
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, app, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _), _, _), _, _, _)::nrest when identifiers.Length > 1 ->
+                match app with
+                | SynExpr.LongIdentSet(SynLongIdent(headIdentifiers, _, _), _, _) when headIdentifiers.Length > 1 ->
+                    Array.append
+                        (issueWargnings bindings headIdentifiers List.empty None)
+                        (issueWargnings bindings identifiers nrest None)
+                | _ ->
+                    issueWargnings bindings identifiers nrest (Some app)
+            | SynBinding(_, _, _, _, _, _, _, _, _, SynExpr.LetOrUse(_, _, bindings, SynExpr.Sequential(_, _, SynExpr.LongIdentSet(SynLongIdent(identifiers, _, _), _, _), _, _), _, _), _, _, _)::nrest when identifiers.Length > 1 ->
+                issueWargnings bindings identifiers nrest None
             | _ -> traverse rest (extraFromBindings bindings classInstances) instancesWithMethodCall
         | _::rest -> traverse rest classInstances instancesWithMethodCall
         | [] -> Array.empty

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -88,3 +88,4 @@ let UnnestedFunctionNames = identifier 80
 let NestedFunctionNames = identifier 81
 let UsedUnderscorePrefixedElements = identifier 82
 let UnneededRecKeyword = identifier 83
+let FavourNonMutablePropertyInitialization = identifier 84

--- a/src/FSharpLint.Core/Text.resx
+++ b/src/FSharpLint.Core/Text.resx
@@ -363,4 +363,7 @@
   <data name="RulesUnneededRecKeyword" xml:space="preserve">
     <value>The '{0}' function has a "rec" keyword, but it is not really recursive, consider removing it.</value>
   </data>
+  <data name="RulesFavourNonMutablePropertyInitializationError" xml:space="preserve">
+    <value>Consider using non-mutable property initialization.</value>
+  </data>
 </root>

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -286,6 +286,7 @@
     "uselessBinding": { "enabled": true },
     "tupleOfWildcards": { "enabled": true },
     "favourTypedIgnore": { "enabled": false },
+    "favourNonMutablePropertyInitialization": { "enabled": false },
     "favourReRaise": { "enabled": true },
     "favourStaticEmptyFields": { "enabled": false },
     "favourConsistentThis": {

--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -286,7 +286,7 @@
     "uselessBinding": { "enabled": true },
     "tupleOfWildcards": { "enabled": true },
     "favourTypedIgnore": { "enabled": false },
-    "favourNonMutablePropertyInitialization": { "enabled": false },
+    "favourNonMutablePropertyInitialization": { "enabled": true },
     "favourReRaise": { "enabled": true },
     "favourStaticEmptyFields": { "enabled": false },
     "favourConsistentThis": {

--- a/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
+++ b/tests/FSharpLint.Core.Tests/FSharpLint.Core.Tests.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="Rules\Conventions\AvoidSinglePipeOperator.fs" />
     <Compile Include="Rules\Conventions\SuggestUseAutoProperty.fs" />
     <Compile Include="Rules\Conventions\UsedUnderscorePrefixedElements.fs" />
+    <Compile Include="Rules\Conventions\FavourNonMutablePropertyInitialization.fs" />
     <Compile Include="Rules\Conventions\Naming\NamingHelpers.fs" />
     <Compile Include="Rules\Conventions\Naming\InterfaceNames.fs" />
     <Compile Include="Rules\Conventions\Naming\ExceptionNames.fs" />

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -74,6 +74,22 @@ module Program =
         Assert.IsTrue this.ErrorsExist
 
     [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError_5() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    // A write-only property.
+    member this.MyWriteOnlyProperty with set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2
+        ()"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
     member this.FavourNonMutablePropertyInitializationShouldNotProduceError1() =
         this.Parse """
 type SomeClass() =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -1,0 +1,151 @@
+module FSharpLint.Core.Tests.Rules.Conventions.FavourNonMutablePropertyInitialization
+
+open NUnit.Framework
+open FSharpLint.Rules
+
+[<TestFixture>]
+type TestConventionsFavourNonMutablePropertyInitialization() =
+    inherit TestAstNodeRuleBase.TestAstNodeRuleBase(FavourNonMutablePropertyInitialization.rule)
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError1() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    // A write-only property.
+    member this.MyWriteOnlyProperty with set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError2() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    // A read-write property.
+    member this.MyReadWriteProperty
+        with get () = myInternalValue
+        and set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass()
+        someInstance.MyReadWriteProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError3() =
+        this.Parse """
+open System.Net
+
+module Program =
+    let someFunction() =
+        // System.Net.Cookie implementation lives in a referenced assembly
+        let someInstance = Cookie()
+        someInstance.Domain <- "example.com"
+"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError4() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    static member SomeStaticMethod() =
+        () // any code goes here
+    // A read-write property.
+    member this.MyReadWriteProperty
+        with get () = myInternalValue
+        and set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass()
+        SomeClass.SomeStaticMethod()
+        someInstance.MyReadWriteProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldNotProduceError1() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    // A write-only property.
+    member this.MyWriteOnlyProperty with set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass(MyWriteOnlyProperty = 2)
+        ()"""
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldNotProduceError2() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    // A read-write property.
+    member this.MyReadWriteProperty
+        with get () = myInternalValue
+        and set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction() =
+        let someInstance = SomeClass(MyReadWriteProperty = 2)
+        ()"""
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldNotProduceError3() =
+        this.Parse """
+type SomeClass() =
+    let mutable myInternalValue = 1
+    member this.SomeMethod() =
+        () // some code here
+    // A read-write property.
+    member this.MyReadWriteProperty
+        with get () = myInternalValue
+        and set (value) = myInternalValue <- value
+
+module Program =
+    let someFunction =
+        let someInstance = SomeClass()
+        someInstance.SomeMethod()
+        someInstance.MyReadWriteProperty <- 2"""
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldNotProduceError4() =
+        this.Parse """
+module SomeModule =
+    let mutable myInternalValue = 1
+
+module Program =
+    let someFunction() =
+        SomeModule.myInternalValue <- 2"""
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldNotProduceError5() =
+        this.Parse """
+open System.Net
+
+module Program =
+    let someFunction() =
+        // System.Net.Cookie implementation lives in a referenced assembly
+        let someInstance = Cookie(Domain = "example.com")
+        ()"""
+
+        Assert.IsTrue this.NoErrorsExist

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -74,7 +74,7 @@ module Program =
         Assert.IsTrue this.ErrorsExist
 
     [<Test>]
-    member this.FavourNonMutablePropertyInitializationShouldProduceError_5() =
+    member this.FavourNonMutablePropertyInitializationShouldProduceError5() =
         this.Parse """
 type SomeClass() =
     let mutable myInternalValue = 1
@@ -163,5 +163,15 @@ module Program =
         // System.Net.Cookie implementation lives in a referenced assembly
         let someInstance = Cookie(Domain = "example.com")
         ()"""
+
+        Assert.IsTrue this.NoErrorsExist
+
+    [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should not produce error on local variables``() =
+        this.Parse """
+let someFunc () =
+    let mutable current = 23
+    current <- 2
+    ()"""
 
         Assert.IsTrue this.NoErrorsExist

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -106,6 +106,77 @@ module Program =
         Assert.IsTrue <| this.ErrorExistsAt(10, 21)
 
     [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should produce error in match expression``() =
+        this.Parse """
+type SomeClass() =
+    member val MyWriteOnlyProperty = 0 with set
+
+let someValue =
+    match () with
+    | _ ->
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should produce error in lambda function``() =
+        this.Parse """
+type SomeClass() =
+    member val MyWriteOnlyProperty = 0 with set
+
+let someLambda =
+    fun x ->
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should produce error in try-with block``() =
+        this.Parse """
+type SomeClass() =
+    member val MyWriteOnlyProperty = 0 with set
+
+let someValue =
+    try
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2
+    with
+    | _ -> ()"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should produce error in finally block``() =
+        this.Parse """
+type SomeClass() =
+    member val MyWriteOnlyProperty = 0 with set
+
+let someValue =
+    try
+        ()
+    finally
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``FavourNonMutablePropertyInitialization should produce error in computation expression``() =
+        this.Parse """
+type SomeClass() =
+    member val MyWriteOnlyProperty = 0 with set
+
+let someValue =
+    async {
+        let someInstance = SomeClass()
+        someInstance.MyWriteOnlyProperty <- 2
+    }"""
+
+        Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
     member this.FavourNonMutablePropertyInitializationShouldNotProduceError1() =
         this.Parse """
 type SomeClass() =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/FavourNonMutablePropertyInitialization.fs
@@ -90,6 +90,22 @@ module Program =
         Assert.IsTrue this.ErrorsExist
 
     [<Test>]
+    member this.FavourNonMutablePropertyInitializationShouldProduceError6() =
+        this.Parse """
+type SomeClass() =
+    member val SomeProperty1 = 0 with get, set
+    member val SomeProperty2 = 10 with get, set
+
+module Program =
+    let someFunction =
+        let someInstance = SomeClass()
+        someInstance.SomeProperty1 <- 2
+        someInstance.SomeProperty2 <- 3"""
+
+        Assert.IsTrue <| this.ErrorExistsAt(9, 21)
+        Assert.IsTrue <| this.ErrorExistsAt(10, 21)
+
+    [<Test>]
     member this.FavourNonMutablePropertyInitializationShouldNotProduceError1() =
         this.Parse """
 type SomeClass() =


### PR DESCRIPTION
Add FavourNonMutablePropertyInitialization rule and tests for it.
Apply suggestions of this rule to FSharpLint code.

Supersedes https://github.com/fsprojects/FSharpLint/pull/662

Fixes https://github.com/fsprojects/FSharpLint/issues/535