### PR TITLE
build: change NoWarn to WarningsNotAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1605</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Use WarningsNotAsErrors rather than NoWarn for NU1605 error as suggested by smoothdeveloper in [1].

[1] https://github.com/fsprojects/FSharpLint/pull/680#issuecomment-1900306608