### PR TITLE
Run the benchmarks using the default runtime rather than trying to fo…

### DIFF
--- a/tests/FSharpLint.Benchmarks/Program.fs
+++ b/tests/FSharpLint.Benchmarks/Program.fs
@@ -10,6 +10,6 @@ let main _ =
     BenchmarkRunner
         .Run<Benchmark>(
             DefaultConfig.Instance
-                .AddJob(Job.Default.WithRuntime(CoreRuntime.Core21))
+                .AddJob(Job.Default)
                 .AddDiagnoser(EtwProfiler())) |> ignore
     0


### PR DESCRIPTION
…rce .NET Core 2.1 (as that won't work when the project is built as .NET 6.0)

refs #620 

It looks like BenchmarkDotNet was updated in #657 and that has fixed the ```Microsoft.Diagnostics.Tracing.TraceEvent``` related error, so now it just needs updtaing to not try running as .NET Core 2.1 - if left at default it will run as .NET 6 to match the project settings.

It could alternatively be changed to use ```CoreRuntime.Core60``` if there was a desire to be explicit.
