### PR TITLE
CI: add 2 more triggers

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
+
+  # to execute once a day (more info see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule )
+  schedule:
+    - cron: '0 0 * * *'
+
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
The schedule trigger will run CI everyday to make
sure we catch any breakage caused by external
reasons. The workflow_dispatch one is so that the
repo owner can launch CI jobs manually.