### PR TITLE
Draft: Implement proper rule overriding to address issue #488

### DIFF
--- a/src/FSharpLint.Core/Application/Configuration.fs
+++ b/src/FSharpLint.Core/Application/Configuration.fs
@@ -596,7 +596,7 @@ let loadConfig (configPath:string) =
 let defaultConfiguration =
     let assembly = typeof<Rules.Rule>.GetTypeInfo().Assembly
     let resourceName = Assembly.GetExecutingAssembly().GetManifestResourceNames()
-                       |> Seq.find (fun n -> n.EndsWith("fsharplint.json", System.StringComparison.Ordinal))
+                       |> Seq.find (fun n -> n.EndsWith(SettingsFileName, System.StringComparison.Ordinal))
     use stream = assembly.GetManifestResourceStream(resourceName)
     match stream with
     | null -> failwithf "Resource '%s' not found in assembly '%s'" resourceName (assembly.FullName)

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -383,7 +383,7 @@ module Lint =
             | ex -> Error (string ex)
         | Default ->
             try
-                Configuration.loadConfig "./fsharplint.json"
+                Configuration.loadConfig $"./{Configuration.SettingsFileName}"
                 |> Ok
             with
             | :? System.IO.FileNotFoundException ->


### PR DESCRIPTION
I'm looking to add proper overriding back in. I expect that this will be a breaking change as the current functionality appears to allow running no rules by providing an empty JSON object. The new functionality will run all default enabled rules unless explicitly disabled in a custom config.

For the implementation, there are a few different ways I've considered that require discussion.

1. Keep the default rules in a JSON file, or rewrite them as F# code?
   - JSON File Pros
     - Can be used as an example for providing overrides
     - Single location for changing rules
   - JSON File Cons
     - Default rules are not co-located with the code implementing the rules
     - Code implementing the rules and the settings can become out of sync

   - F# Code Pros
     - Defaults can be co-located with the rules making them easier to keep updated with implementation changes
     - Out of sync defaults becomes a compile time issue
     - Splits the internal and external representations. Right now there there is a single Configuration type that includes deprecated settings. Splitting into Configuration and Override types can keep the internal code cleaner/more focused
   - F# Code Cons
     - Not as easy to show an example of a valid JSON config, but this could be mitigated by including an example config that is used by the FSharp.Data Json type provider. This will allow providing an example overrides file that also stays synchronized with the code base

   Whether the rules are kept in JSON or F#, adding/removing rules or changing defaults results in a new build and version bump.

2. Continue to use the same `Configuration` type, or rename `Configuration` to `Overrides` and create a new `Configuration` type without `optional` to reflect the default config.