### PR TITLE
Update FAKE and remove Paket from build.fsx

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,16 +3,18 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "6.0.0",
+      "version": "6.1.3",
       "commands": [
         "fake"
-      ]
+      ],
+      "rollForward": false
     },
     "fornax": {
       "version": "0.13.1",
       "commands": [
         "fornax"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -39,11 +39,11 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet fake build -t Build
+      run: dotnet fsi build.fsx -t Build
     - name: Run tests
-      run: dotnet fake build -t Test
+      run: dotnet fsi build.fsx -t Test
     - name: Run FSharpLint on itself
-      run: dotnet fake build -t SelfCheck
+      run: dotnet fsi build.fsx -t SelfCheck
 
 
   deployReleaseBinaries:
@@ -59,9 +59,9 @@ jobs:
     - name: Restore tools
       run: dotnet tool restore
     - name: Build
-      run: dotnet fake build
+      run: dotnet fsi build.fsx
     - name: Pack
-      run: dotnet fake build -t Pack
+      run: dotnet fsi build.fsx -t Pack
     - name: Get Changelog Entry
       id: changelog_reader
       uses: mindsers/changelog-reader-action@v1.1.0
@@ -72,7 +72,7 @@ jobs:
       env:
         nuget-key: ${{ secrets.NUGET_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: dotnet fake build -t Push
+      run: dotnet fsi build.fsx -t Push
     - name: Create Release (if tag)
       if: startsWith(github.ref, 'refs/tags/')
       id: create_release
@@ -118,7 +118,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Run Fornax
-      run: dotnet fake build -t Docs
+      run: dotnet fsi build.fsx -t Docs
     - name: Deploy (if tag)
       if: startsWith(github.ref, 'refs/tags/')
       uses: peaceiris/actions-gh-pages@v3

--- a/build.fsx
+++ b/build.fsx
@@ -1,8 +1,33 @@
 // --------------------------------------------------------------------------------------
 // FAKE build script
 // --------------------------------------------------------------------------------------
-#r "paket: groupref build //"
+#r "nuget: MSBuild.StructuredLogger"
+#r "nuget: Fake.Core"
+#r "nuget: Fake.Core.Target"
+#r "nuget: Fake.Core.Process"
+#r "nuget: Fake.DotNet.Cli"
+#r "nuget: Fake.Core.ReleaseNotes"
+#r "nuget: Fake.DotNet.AssemblyInfoFile"
+#r "nuget: Fake.DotNet.Paket"
+#r "nuget: Fake.Tools.Git"
+#r "nuget: Fake.Core.Environment"
+#r "nuget: Fake.Core.UserInput"
+#r "nuget: Fake.IO.FileSystem"
+#r "nuget: Fake.DotNet.MsBuild"
+#r "nuget: Fake.Api.GitHub"
+
+#if FAKE
 #load ".fake/build.fsx/intellisense.fsx"
+#else
+// Boilerplate
+System.Environment.GetCommandLineArgs()
+|> Array.skip 2 // skip fsi.exe; build.fsx
+|> Array.toList
+|> Fake.Core.Context.FakeExecutionContext.Create false __SOURCE_FILE__
+|> Fake.Core.Context.RuntimeContext.Fake
+|> Fake.Core.Context.setExecutionContext
+
+#endif
 
 open Fake.Core
 open Fake.DotNet


### PR DESCRIPTION
Based on https://github.com/fsprojects/FSharpLint/pull/715

This runs for me locally if I do ```dotnet fsi build.fsx``` but if I run it via ```fake-cli``` I get 

```
Script is not valid:
        S:\GitHubForks\FSharpLint\build.fsx (4,0)-(4,36): Error FS0999: S:\GitHubForks\FSharpLint\.fake\build.fsx\compilerTempDir\Projects\4948--5c400694-9997-45d2-a14a-05482cb9a740\Project.fsproj : error NU1008: The following PackageReference items cannot define a value for Version: MSBuild.StructuredLogger, Fake.Core, Fake.Core.Target, Fake.Core.Process, Fake.DotNet.Cli, Fake.Core.ReleaseNotes, Fake.DotNet.AssemblyInfoFile, Fake.DotNet.Paket, Fake.Tools.Git, Fake.Core.Environment, Fake.Core.UserInput, Fake.IO.FileSystem, Fake.DotNet.MsBuild, Fake.Api.GitHub. Projects using Central Package Management must define a Version value on a PackageVersion item. For more information, visit https://aka.ms/nuget/cpm/gettingstarted
```

Actually I'm not sure if fake-cli works with NuGet central package management? 
Maybe it doesn't matter at this point and using ```dotnet fsi``` is simpler anyway