### PR TITLE
update the Github CI to use .NET SDK 9.0.201

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -15,7 +15,7 @@ on:
       - '**'
 
 env:
-  DOTNET_VERSION: 6.0.417
+  DOTNET_VERSION: 9.0.201
 
 jobs:
   buildAndTest:


### PR DESCRIPTION
The CI in my fork is still trying to run , but is failing because it installs the .NET 6 SDK which can't build the .NET 9 libs, so - update it

refs https://github.com/Numpsy/FSharpLint/actions/runs/16049171264/job/45287501138#step:5:9