### PR TITLE
Fixed rules violation in the linter code

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -64,7 +64,7 @@ let isNullOrWhiteSpace = System.String.IsNullOrWhiteSpace
 let exec cmd args dir =
     let proc =
         CreateProcess.fromRawCommandLine cmd args
-        |> CreateProcess.ensureExitCodeWithMessage (sprintf "Error while running '%s' with args: %s" cmd args)
+        |> CreateProcess.ensureExitCodeWithMessage $"Error while running '%s{cmd}' with args: %s{args}"
     (if isNullOrWhiteSpace dir then proc
     else proc |> CreateProcess.withWorkingDirectory dir)
     |> Proc.run
@@ -127,7 +127,7 @@ let nugetVersion =
 
 let PackageReleaseNotes baseProps =
     if isTag then
-        ("PackageReleaseNotes", sprintf "%s/blob/v%s/CHANGELOG.md" gitUrl nugetVersion)::baseProps
+        ("PackageReleaseNotes", $"%s{gitUrl}/blob/v%s{nugetVersion}/CHANGELOG.md")::baseProps
     else
         baseProps
 
@@ -218,7 +218,7 @@ Target.create "Push" (fun _ ->
                 | None ->
                     failwith "GITHUB_SHA should have been populated"
                 | Some commitHash ->
-                    let gitArgs = sprintf "describe --exact-match --tags %s" commitHash
+                    let gitArgs = $"describe --exact-match --tags %s{commitHash}"
                     let proc =
                         CreateProcess.fromRawCommandLine "git" gitArgs
                         |> Proc.run
@@ -238,7 +238,7 @@ Target.create "SelfCheck" (fun _ ->
 
     let consoleProj = Path.Combine(srcDir.FullName, "FSharpLint.Console", "FSharpLint.Console.fsproj") |> FileInfo
     let sol = Path.Combine(rootDir.FullName, "FSharpLint.sln") |> FileInfo
-    exec "dotnet" (sprintf "run lint %s" sol.FullName) consoleProj.Directory.FullName
+    exec "dotnet" $"run lint %s{sol.FullName}" consoleProj.Directory.FullName
 )
 
 // --------------------------------------------------------------------------------------

--- a/src/FSharpLint.Core/Framework/Ast.fs
+++ b/src/FSharpLint.Core/Framework/Ast.fs
@@ -370,7 +370,7 @@ module Ast =
         | SynExpr.DotLambda(_)
         | SynExpr.App(_)
         | SynExpr.Fixed(_)
-        | SynExpr.Typar(_, _) -> ()
+        | SynExpr.Typar(_) -> ()
         | SynExpr.WhileBang(_, expression, expression1, _) ->
             add <| Expression expression1
             add <| Expression expression

--- a/src/FSharpLint.Core/Rules/Identifiers.fs
+++ b/src/FSharpLint.Core/Rules/Identifiers.fs
@@ -1,9 +1,10 @@
+// fsharplint:disable FL0046
 module FSharpLint.Rules.Identifiers
 
 let [<Literal>] private Prefix = "FL"
 
 let identifier (number:int) =
-    sprintf "%s%04d" Prefix number
+    $"%s{Prefix}%04d{number}"
 
 let TupleCommaSpacing = identifier 1
 let TupleIndentation = identifier 2

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SourceLength.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SourceLength.fs
@@ -21,6 +21,7 @@ let generateAbstractMembers numMembers numIndents =
     Array.init numMembers (fun index -> sprintf "abstract member Foo%i : unit -> unit\n" index)
     |> String.concat (String.replicate numIndents " ")
 
+[<Literal>]
 let FunctionLength = 70
 [<TestFixture>]
 type TestMaxLinesInFunction() =
@@ -89,6 +90,7 @@ let dog x =
     ()""" (generateNewLines (FunctionLength - 5) 4))
         Assert.IsFalse this.ErrorsExist
 
+[<Literal>]
 let LambdaFunctionLength = 5
 [<TestFixture>]
 type TestMaxLinesInLambdaFunction() =
@@ -137,6 +139,7 @@ let dog = fun x ->
 
         Assert.IsFalse(this.ErrorExistsAt(4, 10))
 
+[<Literal>]
 let MatchLambdaFunctionLength = 70
 [<TestFixture>]
 type TestMaxLinesInMatchLambdaFunction() =
@@ -166,6 +169,7 @@ let dog = function
 | None -> ()""" (generateNewLines (MatchLambdaFunctionLength - 5) 4))
         Assert.IsFalse(this.ErrorExistsAt(4, 4))
 
+[<Literal>]
 let ValueLength = 70
 [<TestFixture>]
 type TestMaxLinesInValue() =
@@ -191,6 +195,7 @@ let dog =
     ()""" (generateNewLines (ValueLength - 4) 4))
         Assert.IsFalse(this.ErrorExistsAt(4, 4))
 
+[<Literal>]
 let ConstructorLength = 70
 [<TestFixture>]
 type TestMaxLinesInConstructor() =
@@ -219,12 +224,14 @@ type MyClass(x) =
 
         Assert.IsFalse(this.ErrorExistsAt(5, 4))
 
+[<Literal>]
 let MemberLength = 70
 [<TestFixture>]
 type TestMaxLinesInMember() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(MaxLinesInMember.rule { Config.MaxLines = MemberLength })
     // TODO: Add tests.
 
+[<Literal>]
 let PropertyLength = 70
 [<TestFixture>]
 type TestMaxLinesInProperty() =
@@ -242,6 +249,7 @@ type Class() =
 """
         Assert.IsFalse(this.ErrorExistsAt(6, 31))
 
+[<Literal>]
 let ClassLength = 500
 [<TestFixture>]
 type TestMaxLinesInClass() =
@@ -291,12 +299,14 @@ type IPrintable =
 
         Assert.IsFalse(this.ErrorExistsAt(4, 5))
 
+[<Literal>]
 let UnionLength = 500
 [<TestFixture>]
 type TestMaxLinesInUnion() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(MaxLinesInUnion.rule { Config.MaxLines = UnionLength })
     // TODO: Add tests.
 
+[<Literal>]
 let RecordLength = 500
 [<TestFixture>]
 type TestMaxLinesInRecord() =
@@ -324,12 +334,14 @@ type Record = { dog: int }
 
         Assert.IsFalse(this.ErrorExistsAt(4, 5))
 
+[<Literal>]
 let EnumLength = 1000
 [<TestFixture>]
 type TestMaxLinesInEnum() =
     inherit TestAstNodeRuleBase.TestAstNodeRuleBase(MaxLinesInEnum.rule { Config.MaxLines = EnumLength })
     // TODO: Add tests.
 
+[<Literal>]
 let ModuleLength = 1000
 [<TestFixture>]
 type TestMaxLinesInModule() =


### PR DESCRIPTION
* disable `FL0046` for `Identifiers.fs`
* make constants instead of let bindings in `SourceLength.fs`