### PR TITLE
Update the build instructions to use `dotnet fsi` instead of `fake-cli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ Package | Version
 
 1. Make sure you've installed the .NET version defined in [global.json](global.json)
 2. Run `dotnet tool restore` to install all developer tools required to build the project
-3. Run `dotnet fake build -t Build` to build (which executes the `Build` target from the FAKE-based [build script](build.fsx))
-4. To run tests use `dotnet fake build -t Test`
-5. To build documentation use `dotnet fake build -t Docs`
+3. Run `dotnet fsi build.fsx -t Build` to build (which executes the `Build` target from the FAKE-based [build script](build.fsx))
+4. To run tests use `dotnet fsi build.fsx -t Test`
+5. To build documentation use `dotnet fsi build.fsx -t Docs`
 
 ## How to work with documentation
 
 1. Make sure you've installed the .NET version defined in [global.json](global.json)
 2. Run `dotnet tool restore` to install all developer tools required to build the project
-3. Run `dotnet fake build` to build default target of [build script](build.fsx)
-4. Build documentation to make sure everything is fine with `dotnet fake build -t Docs`
+3. Run `dotnet fsi build.fsx` to build default target of [build script](build.fsx)
+4. Build documentation to make sure everything is fine with `dotnet fsi build.fsx -t Docs`
 5. Go to docs folder `cd docs` and start Fornax in watch mode `dotnet fornax watch`
 6. Your documentation should be now accessible on `localhost:8080` and will be regenerated on every file save
 


### PR DESCRIPTION
To match the updated CI.

Maybe completing https://github.com/fsprojects/FSharpLint/pull/660 would be usful, so you don't need to crea about FAKE or whatever if you just want to build the docs?