### PR TITLE
build.fsx: fix working dir when uploading nugets

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -200,7 +200,6 @@ Target.create "Push" (fun _ ->
             o with
                 Common = {
                     o.Common with
-                        WorkingDirectory = nugetDir
                         CustomParams = Some "--skip-duplicate"
                 }
                 PushParams = {


### PR DESCRIPTION
To fix errors like:
```
Starting task 'DotNet:nuget:push': ./out/*.nupkg
./out/> "/usr/share/dotnet/dotnet"  nuget push --skip-duplicate ./out/*.nupkg --api-key <ApiKey> --source https://api.nuget.org/v3/index.json (In: false, Out: false, Err: false)
error: Could not find a part of the path '/home/runner/work/FSharpLint/FSharpLint/out/out'.
```