### PR TITLE
Exit after printing out version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix MSBuild integration sample in docs #750 [@xperiandri]
+- Exit after printing out version information #743 [@numpsy]
 
 ## [0.25.0] - 2025-07-11
 

--- a/src/FSharpLint.Console/Program.fs
+++ b/src/FSharpLint.Console/Program.fs
@@ -85,8 +85,7 @@ let private start (arguments:ParseResults<ToolArgs>) (toolsPath:Ionide.ProjInfo.
             Assembly.GetExecutingAssembly().GetCustomAttributes false
             |> Seq.pick (function | :? AssemblyInformationalVersionAttribute as aiva -> Some aiva.InformationalVersion | _ -> None)
         $"Current version: {version}" |> output.WriteInfo
-        Environment.Exit(0)
-    
+        Environment.Exit 0
     let handleError (str:string) =
         output.WriteError str
         exitCode <- -1

--- a/src/FSharpLint.Console/Program.fs
+++ b/src/FSharpLint.Console/Program.fs
@@ -85,8 +85,8 @@ let private start (arguments:ParseResults<ToolArgs>) (toolsPath:Ionide.ProjInfo.
             Assembly.GetExecutingAssembly().GetCustomAttributes false
             |> Seq.pick (function | :? AssemblyInformationalVersionAttribute as aiva -> Some aiva.InformationalVersion | _ -> None)
         $"Current version: {version}" |> output.WriteInfo
-        ()
-
+        Environment.Exit(0)
+    
     let handleError (str:string) =
         output.WriteError str
         exitCode <- -1

--- a/src/FSharpLint.Console/Program.fs
+++ b/src/FSharpLint.Console/Program.fs
@@ -86,6 +86,7 @@ let private start (arguments:ParseResults<ToolArgs>) (toolsPath:Ionide.ProjInfo.
             |> Seq.pick (function | :? AssemblyInformationalVersionAttribute as aiva -> Some aiva.InformationalVersion | _ -> None)
         $"Current version: {version}" |> output.WriteInfo
         Environment.Exit 0
+
     let handleError (str:string) =
         output.WriteError str
         exitCode <- -1


### PR DESCRIPTION
Rather than then trying to call GetSubCommand() and breaking when there isn't one.

refs https://github.com/fsprojects/FSharpLint/issues/741

Just a thought at a simple change to exit after printing the version information, rather than making a call to GetSubCommand() that can fail if there no other commands specified.

If it needs to support printing the version and then doing a lint, maybe it needs to use TryGetSubCommand() instead.