### PR TITLE
Update docs to note that linting supports `slnx` and `slnf` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix MSBuild integration sample in docs #750 [@xperiandri]
 - Exit after printing out version information #743 [@numpsy]
 - Fix .NET 8 support #748 [@xperiandri]
+- Update docs to note that linting supports `slnx` and `slnf` files #744 [@numpsy]
 
 ## [0.25.0] - 2025-07-11
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -13,7 +13,7 @@ The project aims to let the user know of problems through [matching user defined
 a la [HLint](http://community.haskell.org/~ndm/hlint/), and also by using custom rules written in F# similar to the rules
 in [Mascot](http://mascot.x9c.fr/manual.html) and [StyleCop](http://stylecop.codeplex.com/).
 
-Using a `.fsproj` (F# project) or `.sln / .slnx / .slnf` (F# solution) file the tool will analyse all of the F# implementation files in the project/solution looking for
+Using a `.fsproj` (F# project) or `.sln` / `.slnx` / `.slnf` (F# solution) file the tool will analyse all of the F# implementation files in the project/solution looking for
 code that breaks a set of rules governing the style of the code. Examples of rules: lambda functions must be less than 6 lines long, class member identifiers must be PascalCase.
 
 ## Usage

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -13,7 +13,7 @@ The project aims to let the user know of problems through [matching user defined
 a la [HLint](http://community.haskell.org/~ndm/hlint/), and also by using custom rules written in F# similar to the rules
 in [Mascot](http://mascot.x9c.fr/manual.html) and [StyleCop](http://stylecop.codeplex.com/).
 
-Using a `.fsproj` (F# project) or `.sln` (F# solution) file the tool will analyse all of the F# implementation files in the project/solution looking for
+Using a `.fsproj` (F# project) or `.sln / .slnx / .slnf` (F# solution) file the tool will analyse all of the F# implementation files in the project/solution looking for
 code that breaks a set of rules governing the style of the code. Examples of rules: lambda functions must be less than 6 lines long, class member identifiers must be PascalCase.
 
 ## Usage

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -454,7 +454,7 @@ module Lint =
             FailedToLoadFile projectFilePath
             |> LintResult.Failure
 
-    /// Lints an entire F# solution by linting all projects specified in the `.sln` file.
+    /// Lints an entire F# solution by linting all projects specified in the `.sln`, `slnx` or `.slnf` file.
     let lintSolution (optionalParams:OptionalLintParameters) (solutionFilePath:string) (toolsPath:Ionide.ProjInfo.Types.ToolsPath) =
         if IO.File.Exists solutionFilePath then
             let solutionFilePath = Path.GetFullPath solutionFilePath

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -125,7 +125,7 @@ module Lint =
     /// Runs all rules which take a line of text as input.
     val runLineRules : LineRules -> Rules.GlobalRuleConfig -> string -> string -> string [] -> Context -> Suggestion.LintWarning []
 
-    /// Lints an entire F# solution by linting all projects specified in the `.sln` file.
+    /// Lints an entire F# solution by linting all projects specified in the `.sln`, `slnx` or `.slnf` file.
     val lintSolution : optionalParams:OptionalLintParameters -> solutionFilePath:string -> toolsPath:Ionide.ProjInfo.Types.ToolsPath -> LintResult
 
     /// Lints an entire F# project by retrieving the files from a given


### PR DESCRIPTION
Updates two places in the documentation to mention slnx/f files where it currently mentions .sln

1) On the [front page of the docs](https://fsprojects.github.io/FSharpLint/) from 

<img width="537" height="87" alt="image" src="https://github.com/user-attachments/assets/4dc1e748-6cd0-4f00-be0e-aea8d92d6dbc" />

to 

<img width="515" height="132" alt="image" src="https://github.com/user-attachments/assets/62eda10c-ce28-4c62-a696-3c5d88048726" />


2) In the [API docs for the lint function](https://fsprojects.github.io/FSharpLint/reference/FSharpLint.Core/fsharplint-application-lint.html)
From
<img width="1115" height="71" alt="image" src="https://github.com/user-attachments/assets/687c3a80-16b9-4b3f-9722-9a8a8c26a367" />

To:
<img width="1263" height="90" alt="image" src="https://github.com/user-attachments/assets/7aef8550-dc5d-4dc7-afbe-8d6c104b67e5" />
