### PR TITLE
Fixed MSBuild integration sample in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fix MSBuild integration sample in docs #750 [@xperiandri]
+
 ## [0.25.0] - 2025-07-11
 
 - Migrate from `Paket` to `Directory.Packages.props` #722 [@xperiandri]

--- a/docs/content/how-tos/msbuild-task.md
+++ b/docs/content/how-tos/msbuild-task.md
@@ -12,7 +12,7 @@ To set this up, first [install the FSharpLint dotnet tool](install-dotnet-tool.h
 
 Then, you can add the following to any of your projects to run linting after build completion for that project:
 
-    <Target Name="FSharpLint" AfterTargets="BeforeBuild">
+    <Target Name="FSharpLint" AfterTargets="BeforeBuild" Condition="'$(DesignTimeBuild)' != 'true'">
      <Exec
        Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
        ConsoleToMsBuild="true"
@@ -20,4 +20,12 @@ Then, you can add the following to any of your projects to run linting after bui
      />
     </Target>
 
-If you would like to enable linting for all projects, you can add the above target to either a `Directory.Build.props` or `Directory.Build.targets` file in the root of your repository. This will add the target to all files. See [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019) for more info
+If you would like to enable linting for all projects, you can add the following target to either a `Directory.Build.props` or `Directory.Build.targets` file in the root of your repository. This will add the target to all F# projects. See [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019) for more info
+
+    <Target Name="FSharpLint" AfterTargets="BeforeBuild" Condition="'$(MSBuildProjectExtension)'=='.fsproj' AND '$(DesignTimeBuild)' != 'true'">
+     <Exec
+       Command="dotnet fsharplint -f msbuild lint --lint-config $(MSBuildThisFileDirectory)/fsharplint.json $(MSBuildProjectFullPath)"
+       ConsoleToMsBuild="true"
+       IgnoreExitCode="false"
+     />
+    </Target>

--- a/src/FSharpLint.Console/FSharpLint.Console.fsproj
+++ b/src/FSharpLint.Console/FSharpLint.Console.fsproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="Properties\launchSettings.json" Condition="Exists('Properties\launchSettings.json')" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Output.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #747 

Without `'$(DesignTimeBuild)' != 'true'"`:
- Visual Studio build never ends
- `dotnet build` hangs the whole PC