### PR TITLE
Fix ParameterNames rule

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/ParameterNames.fs
@@ -41,7 +41,7 @@ let private getIdentifiers (args:AstNodeRuleParams) =
     | AstNode.Binding(SynBinding(access, _, _, _, attributes, _, valData, pattern, _, _, _, _, _)) ->
         if not (isLiteral attributes) then
             match identifierTypeFromValData valData with
-            | Value | Function ->
+            | Function ->
                 let accessControlLevel = getAccessControlLevel args.SyntaxArray args.NodeIndex
                 getPatternIdents accessControlLevel (getValueOrFunctionIdents args.CheckInfo) true pattern
             | Member | Property ->

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
@@ -114,3 +114,14 @@ let foo ((x, y) as bar_coord) = bar_coord
 """
 
         Assert.IsTrue this.ErrorsExist
+
+    [<Test>]
+    member this.``Module members should not cause errors as they are not parameters``() =
+        this.Parse """
+module BitLaunch =
+    module Regions =
+        let Bucharest = "Bucharest"
+        let Amsterdam someArg = "Amsterdam"
+"""
+        
+        Assert.IsFalse this.ErrorsExist

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/ParameterNames.fs
@@ -78,13 +78,13 @@ let result = extractInt singleCaseDU
         let source = """
 module Program
 
-let __foo_bar = 0
+let baz __foo_bar = 0
 """
 
         let expected = """
 module Program
 
-let __foobar = 0
+let baz __foobar = 0
 """
 
         this.Parse source


### PR DESCRIPTION
To not fire on member names, because the rule is supposed to operate only on function or method parameters.