### PR TITLE
NestedFunctionNames,UnnestedFunctionNames: fix rules

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -8,10 +8,13 @@ open FSharpLint.Rules.Helper.Naming
 
 let private getIdentifiers (args: AstNodeRuleParams) =
     match args.AstNode with
-    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _, _)) ->
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, valData, pattern, _, _, _, _, _)) ->
         if isNested args args.NodeIndex then
             let maxAccessibility = AccessControlLevel.Public
-            getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
+            match identifierTypeFromValData valData with
+            | Function | Member ->
+                getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
+            | _ -> Array.empty
         else
             Array.empty
     | _ -> Array.empty

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -8,12 +8,15 @@ open FSharpLint.Rules.Helper.Naming
 
 let private getIdentifiers (args: AstNodeRuleParams) =
     match args.AstNode with
-    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, _, pattern, _, _, _, _,_)) ->
+    | AstNode.Binding (SynBinding (_, _, _, _, _attributes, _, valData, pattern, _, _, _, _,_)) ->
         if isNested args args.NodeIndex then
             Array.empty
         else
             let maxAccessibility = AccessControlLevel.Public
-            getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
+            match identifierTypeFromValData valData with
+            | Function | Member ->
+                getPatternIdents maxAccessibility (fun _a11y innerPattern -> getFunctionIdents innerPattern) true pattern
+            | _ -> Array.empty
     | _ -> Array.empty
 
 let rule config =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -108,3 +108,14 @@ module Program =
 """
 
         this.AssertNoWarnings()
+
+    [<Test>]
+    member this.``Bindings that are not functions should not cause errors``() =
+        this.Parse """
+module Program =
+    let OuterFunction () =
+        let BLUE_STATE = "blue"
+        ()
+"""
+
+        this.AssertNoWarnings()

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/NestedFunctionNames.fs
@@ -55,6 +55,20 @@ module Program =
         Assert.IsTrue(this.ErrorExistsAt(4, 12))
 
     [<Test>]
+    member this.NestedFunctionNameWithNoParametersIsPascalCase() =
+        this.Parse """
+module Program =
+    let CylinderVolume () =
+        let NestedFunction () =
+            1
+
+        let pi = 3.14159
+        pi * 2
+"""
+
+        Assert.IsTrue(this.ErrorExistsAt(4, 12))
+
+    [<Test>]
     member this.NestedFunctionNameInTypeIsPascalCase() =
         this.Parse """
 type Record =

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/Naming/UnnestedFunctionNames.fs
@@ -199,3 +199,12 @@ module Program =
 """
 
         Assert.IsTrue(this.ErrorExistsAt(8, 8))
+
+    [<Test>]
+    member this.``Bindings that are not functions should not cause errors``() =
+        this.Parse """
+module Program =
+    let BLUE_STATE = "blue"
+"""
+
+        this.AssertNoWarnings()


### PR DESCRIPTION
Fixed rules to only take into account function and method names.

Added test cases make sure the rule doesn't fire on bindings that are not functions.