### PR TITLE
SuggestUseAutoProperty: don't apply to structs

### DIFF
--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/SuggestUseAutoProperty.fs
@@ -106,3 +106,13 @@ type Foo(content: int) =
 
         this.Parse source
         Assert.AreEqual(expected, this.ApplyQuickFix source)
+
+    [<Test>]
+    member this.``Should not suggest using auto-property for types with [<Struct>] attribute`` () =
+        this.Parse """
+[<Struct>]
+type Foo(content: int) =
+    member self.Content = content
+"""
+
+        Assert.IsTrue this.NoErrorsExist


### PR DESCRIPTION
Don't apply rule to types with `[<Struct>]` annotation, because such types cannot have auto-properties.


Also added a test for such case.

Fixes https://github.com/fsprojects/FSharpLint/issues/755