### PR TITLE
Update the 'Running Lint From An Application' documentation to say in…

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -107,7 +107,7 @@ Rules can be disabled within the code using structured comments. See the [Suppre
 
 ## Running Lint From An Application
 
-Install the [`FSharp.Core` nuget package](https://www.nuget.org/packages/FSharpLint.Core/).
+Install the [`FSharpLint.Core` nuget package](https://www.nuget.org/packages/FSharpLint.Core/).
 
 The namespace `FSharpLint.Application` contains a module named `Lint` which provides several functions
 to lint a project/source file/source string.


### PR DESCRIPTION
…stall FSharpLint.Core rather than FSharp.Core

As it stands, the text says 'FSharp.Core' but the link goes to FSharpLint.Core, and It looks like they should both say FSharpLint.Core?