### PR TITLE
Core(HintParser): Change charListToString to use String.Concat

### DIFF
--- a/src/FSharpLint.Core/Framework/HintParser.fs
+++ b/src/FSharpLint.Core/Framework/HintParser.fs
@@ -7,8 +7,8 @@ open HintParserTypes
 
 module HintParser =
 
-    let charListToString charList =
-        Seq.fold (fun concatenatedString charElement -> concatenatedString + charElement.ToString()) String.Empty charList
+    let charListToString (charList: char seq) =
+        String.Concat charList
 
     let pischar chars : Parser<char, 'CharParser> =
         satisfy (fun character -> List.exists ((=) character) chars)


### PR DESCRIPTION
Just a thought I had after running a run of FSharpLint over one of my projects thought the Visual Studio memory profiler. It's quite trivial in the overall schema of things, but in case anyone is interested.

I noticed that ```charListToString``` was creating quite a large number of strings:

![Screenshot 2025-08-10 224138](https://github.com/user-attachments/assets/818ab1fc-c2bd-49bf-b292-d750acd19801)

And I wondered if ```String.Create``` could be used to reduce the number of temporary strings. Doing so got

![Screenshot 2025-08-11 005042](https://github.com/user-attachments/assets/8cc1a68e-b62a-4cb7-9f33-d9c251f02e70)

The actual amounts of memory here are rather small compared to total memory because the strings are tine - 

Before
```
| Method      | Mean    | Error    | StdDev   | Gen0        | Gen1       | Gen2      | Allocated  |
|------------ |--------:|---------:|---------:|------------:|-----------:|----------:|-----------:|
| LintProject | 3.983 s | 0.1033 s | 0.2964 s | 167000.0000 | 22000.0000 | 1000.0000 | 1008.65 MB |
```

After
```
| Method      | Mean    | Error    | StdDev   | Gen0        | Gen1       | Gen2      | Allocated  |
|------------ |--------:|---------:|---------:|------------:|-----------:|----------:|-----------:|
| LintProject | 3.916 s | 0.1088 s | 0.3088 s | 167000.0000 | 22000.0000 | 1000.0000 | 1007.31 MB |
```

But the change is also small so maybe it's still useful.