### PR TITLE
Makefile: don't skip 'docs' target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,7 +405,8 @@ FodyWeavers.xsd
 tmp/
 temp/
 .fsdocs
-docs/
+docs/*
+!docs/Makefile
 
 # ===================================================
 # OS files

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ check:
 selfcheck:
 	dotnet fsi build.fsx --target SelfCheck
 
+# added docs tatget to .PHONY target because, otherwise, as 'docs' dir already exists
+# then Make would consider it "up to date" and would skip execution of the target
+.PHONY: docs
 docs:
-	dotnet fsi build.fsx --target Docs
+	$(MAKE) --directory docs
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,2 @@
+all:
+	dotnet fsi ../build.fsx --target Docs


### PR DESCRIPTION
If there is a file or directory named the same as target
('docs' in this case) in current directory, Make treats that
target as a file target. Since the file (dir in this case)
already exists and has no dependencies (or its dependencies
are older), Make considered it "up to date" and skipped execution.
    
To avoid this, we now use a .PHONY target to tell Make that 'docs'
is not a real file.
    
Fixes https://github.com/fsprojects/FSharpLint/issues/768