### PR TITLE
Update Fornax to 0.16.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fornax": {
-      "version": "0.16.0-beta002",
+      "version": "0.16.0",
       "commands": [
         "fornax"
       ],

--- a/docs/config.fsx
+++ b/docs/config.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 
 open Config
 

--- a/docs/generators/apiref.fsx
+++ b/docs/generators/apiref.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #r "nuget: Markdig, 0.41.3"
 #r "nuget: FSharp.Formatting, 20.0.1"
 

--- a/docs/generators/lunr.fsx
+++ b/docs/generators/lunr.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #r "nuget: FSharp.Formatting, 20.0.1"
 
 #if !FORNAX

--- a/docs/generators/page.fsx
+++ b/docs/generators/page.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #load "partials/layout.fsx"
 
 open Html

--- a/docs/generators/partials/footer.fsx
+++ b/docs/generators/partials/footer.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #if !FORNAX
 #load "../../loaders/contentloader.fsx"
 #load "../../loaders/pageloader.fsx"

--- a/docs/generators/partials/header.fsx
+++ b/docs/generators/partials/header.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #if !FORNAX
 #load "../../loaders/contentloader.fsx"
 #load "../../loaders/pageloader.fsx"

--- a/docs/generators/partials/layout.fsx
+++ b/docs/generators/partials/layout.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #if !FORNAX
 #load "../../loaders/contentloader.fsx"
 #load "../../loaders/pageloader.fsx"

--- a/docs/generators/partials/menu.fsx
+++ b/docs/generators/partials/menu.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #if !FORNAX
 #load "../../loaders/apirefloader.fsx"
 #load "../../loaders/contentloader.fsx"

--- a/docs/loaders/apirefloader.fsx
+++ b/docs/loaders/apirefloader.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #r "nuget: FSharp.Formatting, 20.0.1"
 
 open System

--- a/docs/loaders/contentloader.fsx
+++ b/docs/loaders/contentloader.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 #r "nuget: Markdig, 0.41.3"
 open Markdig
 open System

--- a/docs/loaders/copyloader.fsx
+++ b/docs/loaders/copyloader.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 
 open System.IO
 

--- a/docs/loaders/globalloader.fsx
+++ b/docs/loaders/globalloader.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 
 type SiteInfo = {
     title: string

--- a/docs/loaders/pageloader.fsx
+++ b/docs/loaders/pageloader.fsx
@@ -1,4 +1,4 @@
-#r "nuget: Fornax.Core, 0.16.0-beta002"
+#r "nuget: Fornax.Core, 0.16.0"
 
 type Shortcut = {
     title: string


### PR DESCRIPTION
The FSharp.Core dependency in Fornax.Core has been changed from ```= 8.0.100``` to ```>= 6.0.7``` which should hopefully fix these warnings in the docs build:

<img width="1409" height="192" alt="image" src="https://github.com/user-attachments/assets/506744ec-e110-4ee9-bee6-a51d26ead6fb" />
