### PR TITLE
Update Microsoft.Build dependencies to pick up fix for CVE-2025-55247

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,11 +15,11 @@
     <PackageVersion Include="Ionide.ProjInfo.FCS" Version="0.70.2" />
     <PackageVersion Include="Ionide.ProjInfo" Version="0.70.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
+    <PackageVersion Include="Microsoft.Build" Version="17.14.28" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.8" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.28" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.28" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/src/FSharpLint.Core/FSharpLint.Core.fsproj
+++ b/src/FSharpLint.Core/FSharpLint.Core.fsproj
@@ -148,7 +148,7 @@
     <PackageReference Include="Ionide.ProjInfo.FCS" />
     <PackageReference Include="Ionide.ProjInfo" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-    <PackageReference Update="Microsoft.Build" ExcludeAssets="runtime" Condition="$(TargetFramework) == 'net8.0'" VersionOverride="17.11.31" />
+    <PackageReference Update="Microsoft.Build" ExcludeAssets="runtime" Condition="$(TargetFramework) == 'net8.0'" VersionOverride="17.11.48" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />


### PR DESCRIPTION
The versions its currently using are listed as suffering from https://github.com/advisories/GHSA-w3q9-fxm7-j8fq.

When I try to build the current code locally, it fails to build because the build has warnings-as-errors enabled, and NuGet package auditing flags up the CVE with a build warning..

So - maybe the dependencies need to be updated to the fixed versions?