### PR TITLE
Update .NET version & drop setup steps to fix CI

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -27,10 +27,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
     - name: Restore tools
       run: dotnet tool restore
     - name: Restore dependencies
@@ -49,10 +45,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
     - name: Restore tools
       run: dotnet tool restore
     - name: Build
@@ -104,11 +96,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
-
     - name: Restore tools
       run: dotnet tool restore
     - name: Restore dependencies

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.201",
+    "version": "9.0.306",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
Updated .NET9.x minor version and dropped setup-.NET steps in GitHubActions in order to fix CI build of the `docs` job.

Somehow, on the same day as the .NETv10 release, our CI started failing without changing anything (thanks to our
`on: schedule: cron:` trigger we detected this, as it runs daily), but only in the docs job. After some discussion about Fornax in PRs 770 and 779 (given that we updated this dep in PR#767 recently), it was discovered that the default .NET version of current GitHubActions agents works out of of the box without needing to run any setup-dotnet action.

So then, rather than just removing the step in the docs job, let's remove it from all of them to be consistent; and we might revisit this decision in the future if/when the default versions change again (which might make CI jobs fail again).