### PR TITLE
Remove fake-cli from dotnet-tools.json

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,13 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fake-cli": {
-      "version": "6.1.3",
-      "commands": [
-        "fake"
-      ],
-      "rollForward": false
-    },
     "fornax": {
       "version": "0.16.0",
       "commands": [


### PR DESCRIPTION
It's not used any more, so here shouldn't be a need to install it.

Just a thought - if it's not used now that build.fsx is run with ```dotnet fsi``` then there's no need to spend time restoring it in the CI builds.