### PR TITLE
global.json: relax rollForward policy to fix CI

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "9.0.306",
-    "rollForward": "disable"
+    "rollForward": "minor"
   }
 }


### PR DESCRIPTION
Recent fix [1] for our scheduled CI build didn't last long. Suddenly the "Restore tools" step (`dotnet tool restore`) started failing in Linux because the GithubActions agent's dotnet version was apparently upgraded from 9.0.306 to 9.0.307. Given this, the most sensible approach to fix this is revisit our RollForward policy, which was disabled in a recent PR [2] because of apparent issues when upgrading our docs generation.

That issue seems to not be happenning anymore because our CIs are green even when we upgraded to a .NET version newer than 9.0.300 (maybe thanks to our Fornax dependency upgrade?), so it seems safe to restore to a "Minor" setting here.

[1] https://github.com/fsprojects/FSharpLint/pull/780
[2] https://github.com/fsprojects/FSharpLint/pull/736