### PR TITLE
CI: use fetch-depth:0 for release job

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -43,6 +43,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+      with:
+        # we need fetch-depth: 0 because we use the `git describe` command in build.fsx
+        fetch-depth: 0
+
     - name: Restore tools
       run: dotnet tool restore
     - name: Build

--- a/build.fsx
+++ b/build.fsx
@@ -224,6 +224,7 @@ Target.create "Push" (fun _ ->
                 | None ->
                     failwith "GITHUB_SHA should have been populated"
                 | Some commitHash ->
+                    // NOTE: for this to work, github workflow needs to have `fetch-depth: 0` in its checkout action
                     let gitArgs = $"describe --exact-match --tags %s{commitHash}"
                     let proc =
                         CreateProcess.fromRawCommandLine "git" gitArgs


### PR DESCRIPTION
We use the `git describe` command to prevent release-notes commits to create nuget prereleases for commits that have already been tagged as a "non-pre" release; see: fa788dbdeddb2984503a24565547f72d93ef4311

However, this stopped working since someone upgraded the checkout action to v4:
a2b2d9427436bd49fe6f6fbe443b14ab2bdbc6a3

What must be happening is that this new version of this action now uses a depth of 1 by default, to save bandwidth, and then the command `git describe` fails with this error:

```
fatal: No names found, cannot describe anything.
```

There's a good StackOverflow entry about this issue, and someone recommends `fetch-depth: 0` there to fix it: https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything#comment118391143_45993185