### PR TITLE
Core,Tests: use Map instead of Dictionary in hint parser

### DIFF
--- a/src/FSharpLint.Core/Framework/HintParserUtilities.fs
+++ b/src/FSharpLint.Core/Framework/HintParserUtilities.fs
@@ -59,7 +59,7 @@ module MergeSyntaxTrees =
 
     and [<CustomEquality; NoComparison>] Edges =
         {
-            Lookup: Dictionary<int, Node>
+            Lookup: Map<int, Node>
             AnyMatch: (char option * Node) list
         }
 
@@ -79,7 +79,7 @@ module MergeSyntaxTrees =
 
         static member Empty =
             {
-                Lookup = Dictionary<_, _>()
+                Lookup = Map.empty
                 AnyMatch = List.Empty
             }
 
@@ -270,15 +270,15 @@ module MergeSyntaxTrees =
 
     let mergeHints hints =
         let rec getEdges transposed =
-            let map = Dictionary<_, _>()
-
-            transposed
-            |> List.choose (function
-                | HintNode(expr, depth, rest) -> Some(getKey expr, expr, depth, rest)
-                | EndOfHint(_) -> None)
-            |> List.filter (isAnyMatch >> not)
-            |> Seq.groupBy (fun (key, expr, _, _) -> Utilities.hash2 key (getHashCode expr))
-            |> Seq.iter (fun (hashcode, items) -> map.Add(hashcode, mergeHints (getHints items)))
+            let map =
+                transposed
+                |> List.choose (function
+                    | HintNode(expr, depth, rest) -> Some(getKey expr, expr, depth, rest)
+                    | EndOfHint(_) -> None)
+                |> List.filter (isAnyMatch >> not)
+                |> Seq.groupBy (fun (key, expr, _, _) -> Utilities.hash2 key (getHashCode expr))
+                |> Seq.map (fun (hashcode, items) -> (hashcode, mergeHints (getHints items)))
+                |> Map.ofSeq
 
             let anyMatches =
                 transposed

--- a/tests/FSharpLint.Core.Tests/Framework/TestHintParser.fs
+++ b/tests/FSharpLint.Core.Tests/Framework/TestHintParser.fs
@@ -15,11 +15,6 @@ type TestMergeSyntaxTrees() =
 
     [<Test>]
     member _.``Merge two function applications of same function with diff arguments, merged list has common prefix till args.``() =
-        let toDictionary list =
-            let dictionary = Dictionary<int, Node>()
-            for (x, y) in list do dictionary.Add(x, y)
-            dictionary
-
         match (run phint "List.map id ===> id", run phint "List.map woof ===> woof") with
         | Success(hint, _, _), Success(hint2, _, _) ->
             let expectedEdges =
@@ -32,15 +27,15 @@ type TestMergeSyntaxTrees() =
                                     MatchedHint = [hint2] })
                                  (Utilities.hash2 SyntaxHintNode.Identifier "id",
                                   { Edges = Edges.Empty
-                                    MatchedHint = [hint] }) ] |> toDictionary
+                                    MatchedHint = [hint] }) ] |> Map.ofList
                              AnyMatch = [] }
-                         MatchedHint = [] }) ] |> toDictionary
+                         MatchedHint = [] }) ] |> Map.ofList
                   AnyMatch = [] }
 
             let expectedRoot =
                 { Lookup =
                     [(Utilities.hash2 SyntaxHintNode.FuncApp 0,
-                      { Edges = expectedEdges; MatchedHint = [] })] |> toDictionary
+                      { Edges = expectedEdges; MatchedHint = [] })] |> Map.ofList
                   AnyMatch = [] }
 
             let mergedHint = MergeSyntaxTrees.mergeHints [hint; hint2]


### PR DESCRIPTION
To make code less reliant on mutable state.