### PR TITLE
perf(Core): Pass a ProjectOptions into the lint

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -125,6 +125,7 @@ module Lint =
             GlobalConfig: Rules.GlobalRuleConfig
             TypeCheckResults: FSharpCheckFileResults option
             ProjectCheckResults: FSharpCheckProjectResults option
+            ProjectOptions: Lazy<FSharpProjectOptions option>
             FilePath: string
             FileContent: string
             Lines: string[]
@@ -149,6 +150,7 @@ module Lint =
                     Lines = config.Lines
                     CheckInfo = config.TypeCheckResults
                     ProjectCheckInfo = config.ProjectCheckResults
+                    ProjectOptions = config.ProjectOptions
                     GlobalConfig = config.GlobalConfig
                 }
             // Build state for rules with context.
@@ -263,6 +265,10 @@ module Lint =
                         GlobalConfig = enabledRules.GlobalConfig
                         TypeCheckResults = fileInfo.TypeCheckResults
                         ProjectCheckResults = fileInfo.ProjectCheckResults
+                        ProjectOptions = lazy( 
+                            fileInfo.ProjectCheckResults
+                            |> Option.map _.ProjectContext.ProjectOptions
+                        )
                         FilePath = fileInfo.File
                         FileContent = fileInfo.Text
                         Lines = lines

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -129,6 +129,7 @@ module Lint =
             GlobalConfig: Rules.GlobalRuleConfig
             TypeCheckResults: FSharpCheckFileResults option
             ProjectCheckResults: FSharpCheckProjectResults option
+            ProjectOptions: Lazy<FSharpProjectOptions option>
             FilePath: string
             FileContent: string
             Lines: string[]

--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -31,6 +31,7 @@ type AstNodeRuleParams =
       Lines:string []
       CheckInfo:FSharpCheckFileResults option
       ProjectCheckInfo:FSharpCheckProjectResults option
+      ProjectOptions: Lazy<FSharpProjectOptions option>
       GlobalConfig:GlobalRuleConfig }
 
 type LineRuleParams =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/AsynchronousFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/AsynchronousFunctionNames.fs
@@ -32,8 +32,8 @@ let runner (config: Config) (args: AstNodeRuleParams) =
         | _ -> config.Mode = AllAPIs
 
     let likelyhoodOfBeingInLibrary =
-        match args.ProjectCheckInfo with
-        | Some projectInfo -> howLikelyProjectIsLibrary projectInfo.ProjectContext.ProjectOptions.ProjectFileName
+        match args.ProjectOptions.Value with
+        | Some projectOptions -> howLikelyProjectIsLibrary projectOptions.ProjectFileName
         | None -> Unlikely
 
     if config.Mode = OnlyPublicAPIsInLibraries && likelyhoodOfBeingInLibrary <> Likely then

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/SimpleAsyncComplementaryHelpers.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/SimpleAsyncComplementaryHelpers.fs
@@ -205,8 +205,8 @@ let runner (config: Config) (args: AstNodeRuleParams) =
         Array.append (checkFuncs asyncFuncs taskFuncs) (checkFuncs taskFuncs asyncFuncs)
 
     let likelyhoodOfBeingInLibrary =
-        match args.ProjectCheckInfo with
-        | Some projectInfo -> howLikelyProjectIsLibrary projectInfo.ProjectContext.ProjectOptions.ProjectFileName
+        match args.ProjectOptions.Value with
+        | Some projectOptions -> howLikelyProjectIsLibrary projectOptions.ProjectFileName
         | None -> Unlikely
 
     if config.Mode = OnlyPublicAPIsInLibraries && likelyhoodOfBeingInLibrary <> Likely then

--- a/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
+++ b/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
@@ -95,9 +95,9 @@ let checkIfInLibrary (args: AstNodeRuleParams) (range: range) : array<WarningDet
     let ruleNotApplicable =
         isInObsoleteMethodOrFunction (args.GetParents args.NodeIndex)
         ||
-        match (args.CheckInfo, args.ProjectCheckInfo) with
-        | Some checkFileResults, Some checkProjectResults ->
-            let projectFile = System.IO.FileInfo checkProjectResults.ProjectContext.ProjectOptions.ProjectFileName
+        match (args.CheckInfo, args.ProjectOptions.Value) with
+        | Some checkFileResults, Some projectOptions ->
+            let projectFile = System.IO.FileInfo projectOptions.ProjectFileName
             match howLikelyProjectIsLibrary projectFile.Name with
             | Likely -> false
             | Unlikely -> true

--- a/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
@@ -43,6 +43,7 @@ type TestAstNodeRuleBase (rule:Rule) =
                         GlobalConfig = resolvedGlobalConfig
                         TypeCheckResults = checkResult
                         ProjectCheckResults = None
+                        ProjectOptions = Lazy<_>(None)
                         FilePath = (Option.defaultValue String.Empty maybeFileName)
                         FileContent = input
                         Lines = (input.Split("\n"))

--- a/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
@@ -65,6 +65,7 @@ type TestHintMatcherBase () =
                         GlobalConfig = resolvedGlobalConfig
                         TypeCheckResults = checkResult
                         ProjectCheckResults = None
+                        ProjectOptions = Lazy<_>()
                         FilePath = (Option.defaultValue String.Empty maybeFileName)
                         FileContent = input
                         Lines = (input.Split("\n"))

--- a/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
@@ -38,6 +38,7 @@ type TestIndentationRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>(None)
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines

--- a/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
@@ -38,6 +38,7 @@ type TestLineRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>(None)
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines

--- a/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
@@ -38,6 +38,7 @@ type TestNoTabCharactersRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>()
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines


### PR DESCRIPTION
Rather than reading it from FSharpCheckProjectResults on every use, which appears to have a substantional performance cost.

refs #770 (specifically https://github.com/fsprojects/FSharpLint/pull/770#issuecomment-3886871671)

This is an attempt at making the FSharpProjectOptions directly available through the lint options and then constructing it once rather than on every call which seems to have a substantional performance impact.

This is more like how its done in the F# Analyzers SDK, where the project check results and the project options[ are both passed down from the top](https://github.com/ionide/FSharp.Analyzers.SDK/blob/294cae109f63a585c35a6e3e2f196358e248371e/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsi#L104).

I'm also reminded when looking that they also have a ```ProjectFileName``` property on the top level options so that consumers don't need to worry about where it came from. That could potentially be done here given that all consumers as it stands only want the file name, though having the whole options available is more extensible for the future.

This change does seem to have a positive performance impact with the current code using FCS 43.9 as well as removing the large regression when using 43.10 - 

Build of just this change - https://github.com/Numpsy/FSharpLint/actions/runs/22036364219 (this takes a couple of minutes off the runtime of the self-lint step in the CI runs as compared to the current master)
Build using this change and FCS 43.10.103 - https://github.com/Numpsy/FSharpLint/actions/runs/21925277621