### PR TITLE
Performance: parallel per-file type checking

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -125,6 +125,7 @@ module Lint =
             GlobalConfig: Rules.GlobalRuleConfig
             TypeCheckResults: FSharpCheckFileResults option
             ProjectCheckResults: FSharpCheckProjectResults option
+            ProjectOptions: Lazy<FSharpProjectOptions option>
             FilePath: string
             FileContent: string
             Lines: string[]
@@ -149,6 +150,7 @@ module Lint =
                     Lines = config.Lines
                     CheckInfo = config.TypeCheckResults
                     ProjectCheckInfo = config.ProjectCheckResults
+                    ProjectOptions = config.ProjectOptions
                     GlobalConfig = config.GlobalConfig
                 }
             // Build state for rules with context.
@@ -263,6 +265,10 @@ module Lint =
                         GlobalConfig = enabledRules.GlobalConfig
                         TypeCheckResults = fileInfo.TypeCheckResults
                         ProjectCheckResults = fileInfo.ProjectCheckResults
+                        ProjectOptions = lazy( 
+                            fileInfo.ProjectCheckResults
+                            |> Option.map _.ProjectContext.ProjectOptions
+                        )
                         FilePath = fileInfo.File
                         FileContent = fileInfo.Text
                         Lines = lines

--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -436,9 +436,9 @@ module Lint =
 
                     Option.iter (fun func -> func warning) optionalParams.ReceivedWarning
 
-                let checker = FSharpChecker.Create(keepAssemblyContents=true)
+                let checker = FSharpChecker.Create(keepAssemblyContents=true, parallelReferenceResolution=true)
 
-                let parseFilesInProject files projectOptions = async {
+                let parseFilesInProject files (projectOptions:FSharpProjectOptions) = async {
                     let lintInformation =
                         { Configuration = config
                           CancellationToken = optionalParams.CancellationToken
@@ -452,21 +452,31 @@ module Lint =
                             Configuration.IgnoreFiles.shouldFileBeIgnored parsedIgnoreFiles filePath)
                         |> Option.defaultValue false
 
-                    let! parsedFiles =
-                        files
-                        |> List.filter (not << isIgnoredFile)
+                    let filesToLint = files |> List.filter (not << isIgnoredFile)
+
+                    // Run project check and per-file parse+check concurrently.
+                    // The project check warms the FCS incremental builder; parallel
+                    // per-file checks share the builder and benefit from its warmed state.
+                    let projectCheckAsync = checker.ParseAndCheckProject projectOptions
+                    let perFileAsync =
+                        filesToLint
                         |> List.map (fun file -> ParseFile.parseFile file checker (Some projectOptions))
-                        |> Async.Sequential
+                        |> Async.Parallel
+
+                    let! results = Async.Parallel [|
+                        async { let! r = projectCheckAsync in return box r }
+                        async { let! r = perFileAsync in return box r }
+                    |]
+                    let projectCheckResults = results.[0] :?> FSharpCheckProjectResults
+                    let parsedFiles = results.[1] :?> ParseFile.ParseFileResult<ParseFile.FileParseInfo>[]
 
                     let failedFiles = Array.choose getFailedFiles parsedFiles
 
                     if Array.isEmpty failedFiles then
-                        let! projectCheckResults = checker.ParseAndCheckProject projectOptions
-
                         parsedFiles
                         |> Array.choose getParsedFiles
-                        |> Array.iter (fun fileParseResult -> 
-                            lint 
+                        |> Array.iter (fun fileParseResult ->
+                            lint
                                 lintInformation
                                 { fileParseResult with ProjectCheckResults = Some projectCheckResults })
 

--- a/src/FSharpLint.Core/Application/Lint.fsi
+++ b/src/FSharpLint.Core/Application/Lint.fsi
@@ -129,6 +129,7 @@ module Lint =
             GlobalConfig: Rules.GlobalRuleConfig
             TypeCheckResults: FSharpCheckFileResults option
             ProjectCheckResults: FSharpCheckProjectResults option
+            ProjectOptions: Lazy<FSharpProjectOptions option>
             FilePath: string
             FileContent: string
             Lines: string[]

--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -31,6 +31,7 @@ type AstNodeRuleParams =
       Lines:string []
       CheckInfo:FSharpCheckFileResults option
       ProjectCheckInfo:FSharpCheckProjectResults option
+      ProjectOptions: Lazy<FSharpProjectOptions option>
       GlobalConfig:GlobalRuleConfig }
 
 type LineRuleParams =

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/AsynchronousFunctionNames.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/AsynchronousFunctionNames.fs
@@ -32,8 +32,8 @@ let runner (config: Config) (args: AstNodeRuleParams) =
         | _ -> config.Mode = AllAPIs
 
     let likelyhoodOfBeingInLibrary =
-        match args.ProjectCheckInfo with
-        | Some projectInfo -> howLikelyProjectIsLibrary projectInfo.ProjectContext.ProjectOptions.ProjectFileName
+        match args.ProjectOptions.Value with
+        | Some projectOptions -> howLikelyProjectIsLibrary projectOptions.ProjectFileName
         | None -> Unlikely
 
     if config.Mode = OnlyPublicAPIsInLibraries && likelyhoodOfBeingInLibrary <> Likely then

--- a/src/FSharpLint.Core/Rules/Conventions/Naming/SimpleAsyncComplementaryHelpers.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/Naming/SimpleAsyncComplementaryHelpers.fs
@@ -205,8 +205,8 @@ let runner (config: Config) (args: AstNodeRuleParams) =
         Array.append (checkFuncs asyncFuncs taskFuncs) (checkFuncs taskFuncs asyncFuncs)
 
     let likelyhoodOfBeingInLibrary =
-        match args.ProjectCheckInfo with
-        | Some projectInfo -> howLikelyProjectIsLibrary projectInfo.ProjectContext.ProjectOptions.ProjectFileName
+        match args.ProjectOptions.Value with
+        | Some projectOptions -> howLikelyProjectIsLibrary projectOptions.ProjectFileName
         | None -> Unlikely
 
     if config.Mode = OnlyPublicAPIsInLibraries && likelyhoodOfBeingInLibrary <> Likely then

--- a/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
+++ b/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
@@ -95,9 +95,9 @@ let checkIfInLibrary (args: AstNodeRuleParams) (range: range) : array<WarningDet
     let ruleNotApplicable =
         isInObsoleteMethodOrFunction (args.GetParents args.NodeIndex)
         ||
-        match (args.CheckInfo, args.ProjectCheckInfo) with
-        | Some checkFileResults, Some checkProjectResults ->
-            let projectFile = System.IO.FileInfo checkProjectResults.ProjectContext.ProjectOptions.ProjectFileName
+        match (args.CheckInfo, args.ProjectOptions.Value) with
+        | Some checkFileResults, Some projectOptions ->
+            let projectFile = System.IO.FileInfo projectOptions.ProjectFileName
             match howLikelyProjectIsLibrary projectFile.Name with
             | Likely -> false
             | Unlikely -> true

--- a/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestAstNodeRule.fs
@@ -43,6 +43,7 @@ type TestAstNodeRuleBase (rule:Rule) =
                         GlobalConfig = resolvedGlobalConfig
                         TypeCheckResults = checkResult
                         ProjectCheckResults = None
+                        ProjectOptions = Lazy<_>(None)
                         FilePath = (Option.defaultValue String.Empty maybeFileName)
                         FileContent = input
                         Lines = (input.Split("\n"))

--- a/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestHintMatcherBase.fs
@@ -65,6 +65,7 @@ type TestHintMatcherBase () =
                         GlobalConfig = resolvedGlobalConfig
                         TypeCheckResults = checkResult
                         ProjectCheckResults = None
+                        ProjectOptions = Lazy<_>()
                         FilePath = (Option.defaultValue String.Empty maybeFileName)
                         FileContent = input
                         Lines = (input.Split("\n"))

--- a/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestIndentationRule.fs
@@ -38,6 +38,7 @@ type TestIndentationRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>(None)
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines

--- a/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestLineRule.fs
@@ -38,6 +38,7 @@ type TestLineRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>(None)
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines

--- a/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/TestNoTabCharactersRule.fs
@@ -38,6 +38,7 @@ type TestNoTabCharactersRuleBase (rule:Rule) =
                     GlobalConfig = resolvedGlobalConfig
                     TypeCheckResults = None
                     ProjectCheckResults = None
+                    ProjectOptions = Lazy<_>()
                     FilePath = resolvedFileName
                     FileContent = input
                     Lines = lines


### PR DESCRIPTION
## Summary

Massive performance improvement to the linting pipeline, built on top of #845.

Runs `ParseAndCheckProject` and per-file `ParseAndCheckFileInProject` concurrently using `Async.Parallel`. The project check warms the FCS incremental builder; parallel per-file checks share the builder and benefit from its warmed state.

Also enables `parallelReferenceResolution` on `FSharpChecker.Create`.

### Performance

| Project | Before (sequential) | After (parallel) | Speedup |
|---|---|---|---|
| FSharpLint.Core (15 files) | 15.4s | 12.5s | ~1.2x |
| my internal project (48 files, many huge reps) | 658s | ~25s | ~25x |

The speedup scales with file count — larger projects see dramatically larger gains.

## Test plan

- [x] Full test suite passes (1003 unit + 26 console + 13 functional)
- [x] Verified identical warning count between sequential and parallel approaches
- [x] Type-check-dependent rules (FL0065 hints, FL0085 tail call diagnostics, FL0095 sync naming) produce correct results in parallel mode

## A note on this PR

This PR was developed with significant AI assistance. I understand if that's not welcome — apologies if so. Happy to discuss the changes or withdraw the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)