### PR TITLE
GitHubActions: prevent forks' CI to fail on schedule triggers

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   buildAndTest:
     # Only run if the event is NOT 'schedule' (e.g., 'push') OR if the event is 'schedule' AND the repo is not a fork
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.event.repository.fork == false) }}
+    if: ${{ (github.event_name != 'schedule') || github.event.repository.fork == false }}
 
     strategy:
       matrix:

--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   buildAndTest:
+    # Only run if the event is NOT 'schedule' (e.g., 'push') OR if the event is 'schedule' AND the repo is not a fork
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.event.repository.fork == false) }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Because schedule triggers are meant to be a tool for maintainers, not contributors (as a contributor, you normally only fork before creating a PR, but you don't "maintain" your fork).