### PR TITLE
Restore the console project before running a self-lint on it.

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -187,16 +187,25 @@ jobs:
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
             <packageSources>
+              <clear />
               <add key="local" value="./artifacts" />
+              <add key="nuget" value="https://api.nuget.org/v3/index.json" />
             </packageSources>
-            <disabledPackageSources>
-              <add key="nuget.org" value="true" />
-            </disabledPackageSources>
+            <packageSourceMapping>
+              <packageSource key="nuget">
+                <package pattern="*" />
+              </packageSource>
+              <packageSource key="local">
+                <package pattern="dotnet-fsharplint" />
+              </packageSource>
+            </packageSourceMapping>
           </configuration>
           EOF
       - name: Install FSharpLint from downloaded binaries
         run: dotnet tool install --global dotnet-fsharplint --prerelease
       - name: Add .NET tools to PATH
         run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+      - name: Restore console project
+        run: dotnet restore ./src/FSharpLint.Console/FSharpLint.Console.fsproj
       - name: Lint FSharpLint.Console project
         run: dotnet fsharplint lint ./src/FSharpLint.Console/FSharpLint.Console.fsproj


### PR DESCRIPTION
This also requires updating the test nuget.config file so that nuget.org is reachable. It now uses package mapping to force the usage of a local fsharplint package.

refs the current CI build failiures in the 'testReleaseBinariesWithDotNet10' step. I don't know why the nightly build started failing when the source hadn't changed, but restoring the console project explicitly before doing the lint does appear to fix the current 'Lint failed to parse files' errors.

Maybe this is a simple way to get the CI working again at least.