### PR TITLE
perf(Core): Reduce zero length array allocations

### DIFF
--- a/src/FSharpLint.Core/Framework/Rules.fs
+++ b/src/FSharpLint.Core/Framework/Rules.fs
@@ -97,12 +97,12 @@ let toWarning (identifier:string) (ruleName:string) (filePath:string) (lines:str
 
 let runAstNodeRule (rule:RuleMetadata<AstNodeRuleConfig>) (config:AstNodeRuleParams) =
     rule.RuleConfig.Runner config
-    |> Array.map (toWarning rule.Identifier rule.Name config.FilePath config.Lines)
+    |> Array.mapIfNotEmpty (toWarning rule.Identifier rule.Name config.FilePath config.Lines)
 
 let runLineRuleWithContext (rule:RuleMetadata<LineRuleConfigWithContext<'Context>>) (context:'Context) (config:LineRuleParams) =
     rule.RuleConfig.Runner context config
-    |> Array.map (toWarning rule.Identifier rule.Name config.FilePath config.Lines)
+    |> Array.mapIfNotEmpty (toWarning rule.Identifier rule.Name config.FilePath config.Lines)
 
 let runLineRule (rule:RuleMetadata<LineRuleConfig>) (config:LineRuleParams) =
     rule.RuleConfig.Runner config
-    |> Array.map (toWarning rule.Identifier rule.Name config.FilePath config.Lines)
+    |> Array.mapIfNotEmpty (toWarning rule.Identifier rule.Name config.FilePath config.Lines)

--- a/src/FSharpLint.Core/Framework/Utilities.fs
+++ b/src/FSharpLint.Core/Framework/Utilities.fs
@@ -23,6 +23,14 @@ module Dictionary =
 
         dict.Add(key, value)
 
+module Array =
+
+    let inline mapIfNotEmpty ([<InlineIfLambda>] mapping: 'Source -> 'Dest) (array: 'Source array) =
+        if Array.isEmpty array then
+            Array.empty
+        else
+            Array.map mapping array
+
 module ExpressionUtilities =
 
     open System


### PR DESCRIPTION
…r to reduce the number of allocated zero length arrays.

As it stands, running the rules allocates a massive number of zero length arrays, which has quite a large effect on the amount of memory allocated. Many of these are from FSharp.Core functions which always create a new array, but which can be avoided with small local wrappers.

-----------

Just trying to get back to looking at some perf tests I started some time back, and found this one.

Running the Visual Studio memory profiler on the functions in the benchmarks project shows the allocations of massive numbers of zero length arrays (over 4 million in total). e.g.

<img width="801" height="233" alt="image" src="https://github.com/user-attachments/assets/b26bd131-bc4d-4146-9239-e1487e955cdd" />

<img width="1315" height="270" alt="image" src="https://github.com/user-attachments/assets/f10d1a3b-750c-44c8-b0de-d9f6d0f4a5bb" />

If I run the benchmarks project with memory diagnosis enabled, I get this with the current code
```
| Method         | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|--------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| LintParsedFile | 878.0 ms | 4.17 ms | 3.70 ms | 25000.0000 | 8000.0000 | 1000.0000 | 396.83 MB |
```

Down to this with this change
```
| Method         | Mean     | Error    | StdDev   | Gen0       | Gen1      | Gen2      | Allocated |
|--------------- |---------:|---------:|---------:|-----------:|----------:|----------:|----------:|
| LintParsedFile | 865.0 ms | 12.17 ms | 10.79 ms | 20000.0000 | 7000.0000 | 1000.0000 | 321.69 MB |
```

If I enable all of the extra checks that are enabled in the 'run self checks' leg of the CI then the differences are even larger.
Before
```
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.402 s | 0.0164 s | 0.0146 s | 43000.0000 | 14000.0000 | 3000.0000 | 726.16 MB |
```

After
```
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.380 s | 0.0141 s | 0.0125 s | 36000.0000 | 11000.0000 | 3000.0000 | 622.94 MB |
```

These allocations are caused by FSHarp.Core liking to always create new arrays in various ```Array``` functions, but to me it looks like it's a big enough gain to special case it locally?...

Note: There are other places that could maybe be changed as well, and a similar situation with Array.collect, but I left it just doing one thing to get comments.