### PR TITLE
Change String::toLines to use ValueOption instead of Option

### DIFF
--- a/src/FSharpLint.Core/Framework/Utilities.fs
+++ b/src/FSharpLint.Core/Framework/Utilities.fs
@@ -150,16 +150,16 @@ module String =
     open System.IO
 
     [<TailCall>]
-    let rec private iterateLines (lines: ResizeArray<string*int*bool>) (readLine: unit -> Option<string>) currentLine index =
+    let rec private iterateLines (lines: ResizeArray<string*int*bool>) (readLine: unit -> ValueOption<string>) currentLine index =
         match currentLine with
-        | Some line ->
+        | ValueSome line ->
             let nextLine = readLine ()
-            let isLastLine = Option.isNone nextLine
+            let isLastLine = ValueOption.isNone nextLine
 
             lines.Add(line, index, isLastLine)
 
             iterateLines lines readLine nextLine (index + 1)
-        | None -> ()
+        | ValueNone -> ()
 
     let toLines input =
         let lines = ResizeArray()
@@ -167,8 +167,8 @@ module String =
 
         let readLine () =
             match reader.ReadLine() with
-            | null -> None
-            | line -> Some line
+            | null -> ValueNone
+            | line -> ValueSome line
 
         iterateLines lines readLine (readLine ()) 0
 


### PR DESCRIPTION
If reduces memory allocations slightly

Just a thought.

Current benchmark project allocation results
```
| Method         | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|--------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| LintParsedFile | 842.2 ms | 5.43 ms | 4.81 ms | 25000.0000 | 8000.0000 | 1000.0000 | 397.55 MB |
```

With this change
```
| Method         | Mean     | Error   | StdDev  | Gen0       | Gen1      | Gen2      | Allocated |
|--------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| LintParsedFile | 837.7 ms | 4.83 ms | 4.29 ms | 25000.0000 | 8000.0000 | 1000.0000 | 396.83 MB |
```