### PR TITLE
Change checkSourceLengthRule to use Span.IsWhiteSpace instead of Stri…

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
@@ -69,7 +69,7 @@ let checkSourceLengthRule (config:Config) range fileContents errorName (skipRang
         let sourceCodeLines = sourceCode.Split([| '\n'; '\r' |]) 
         let blankLinesCount = 
             sourceCodeLines
-            |> Seq.filter (fun line -> line.Trim().Length = 0)
+            |> Seq.filter (fun line -> line.AsSpan().IsWhiteSpace())
             |> Seq.length
 
         let skippedLinesCount =


### PR DESCRIPTION
…ng.Trim

String.Trim can allocate a new string on each call, whereas Span.IsWhiteSpace() shouldn't allocate at all.


Just a thought when looking at some Span related things.
If I run the existing benchmark app using the rule set which is enabled during the SelfCheck part of the CI build then I get this with the current code

```
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.442 s | 0.0155 s | 0.0145 s | 43000.0000 | 13000.0000 | 3000.0000 | 726.17 MB |
```

And this afterwards
```
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.454 s | 0.0094 s | 0.0073 s | 42000.0000 | 13000.0000 | 3000.0000 | 722.76 MB |
```

A small change improvement given the total allocations, but also a small change so I thought it'd still be useful.