### PR TITLE
Fix issue 856

### DIFF
--- a/src/FSharpLint.Core/Framework/AbstractSyntaxArray.fs
+++ b/src/FSharpLint.Core/Framework/AbstractSyntaxArray.fs
@@ -202,6 +202,9 @@ module AbstractSyntaxArray =
         | Expression(SynExpr.Const(SynConst.UInt64(x), _)) -> hash x
         | Pattern(SynPat.Const(SynConst.UIntPtr(x), _))
         | Expression(SynExpr.Const(SynConst.UIntPtr(x), _)) -> hash x
+        | Expression(SynExpr.InterpolatedString(contents, _, _)) ->
+            contents 
+            |> List.fold (fun acc part -> acc ^^^ (part.ToString() |> hash)) 0
         | _ -> 0
 
     [<Struct; NoEquality; NoComparison>]

--- a/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
@@ -982,3 +982,14 @@ res
         this.Parse(source)
         Assert.AreEqual(expected, this.ApplyQuickFix source)
 
+    /// Regression test for: https://github.com/fsprojects/FSharpLint/issues/856
+    [<Test>]
+    member this.``Interpolated strings with different literal text content should be treated as diffrerent``() =
+        this.SetConfig(["if x then y else y ===> y"])
+
+        this.Parse """
+let label (p: int) (currentPage: int) =
+    if p = currentPage then $"Page {p}" else $"Goto page {p}"
+"""
+        
+        Assert.That this.NoErrorsExist


### PR DESCRIPTION
Made getHashCode take into account all parts of interpolated strings. This is needed for hint matcher to distinguish between interpolated strings with the same fill expressions but different literal text segments.

Also added a regression test.

Fixes https://github.com/fsprojects/FSharpLint/issues/856