### PR TITLE
CI,build: try again to fix `git describe` call

### DIFF
--- a/.github/workflows/build+test+deploy.yml
+++ b/.github/workflows/build+test+deploy.yml
@@ -45,8 +45,9 @@ jobs:
     - uses: actions/checkout@v4
 
       with:
-        # we need fetch-depth: 0 because we use the `git describe` command in build.fsx
+        # we need these fetch options because we use the `git describe` command in build.fsx
         fetch-depth: 0
+        fetch-tags: true
 
     - name: Restore tools
       run: dotnet tool restore
@@ -69,6 +70,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+      with:
+        # we need these fetch options because we use the `git describe` command in build.fsx
+        fetch-depth: 0
+        fetch-tags: true
+
     - name: Restore tools
       run: dotnet tool restore
     - name: Download artifact

--- a/build.fsx
+++ b/build.fsx
@@ -224,7 +224,7 @@ Target.create "Push" (fun _ ->
                 | None ->
                     failwith "GITHUB_SHA should have been populated"
                 | Some commitHash ->
-                    // NOTE: for this to work, github workflow needs to have `fetch-depth: 0` in its checkout action
+                    // NOTE: for this to work, github workflow likely needs to have `fetch-depth: 0` && `fetch-tags: true` in its checkout action
                     let gitArgs = $"describe --exact-match --tags %s{commitHash}"
                     let proc =
                         CreateProcess.fromRawCommandLine "git" gitArgs


### PR DESCRIPTION
Our last try[1] to fix the call to `git describe` (to prevent pre-release binaries to be created for tag commits) still didn't seem to work, but with the extra fetch-tags:true option and propagating them to right job should definitely fix it for the next release.

[1] a2da4137f70e5484d170aed3647fef7617447075