### PR TITLE
perf(Core/SourceLength): swap AsSpan with IsNullOrWhiteSpace

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
@@ -69,7 +69,7 @@ let checkSourceLengthRule (config:Config) range fileContents errorName (skipRang
         let sourceCodeLines = sourceCode.Split([| '\n'; '\r' |]) 
         let blankLinesCount = 
             sourceCodeLines
-            |> Seq.filter (fun line -> line.AsSpan().IsWhiteSpace())
+            |> Seq.filter String.IsNullOrWhiteSpace
             |> Seq.length
 
         let skippedLinesCount =


### PR DESCRIPTION
Recent PR[1] changed this hot-path from `Trim().Length<>0` to `AsSpan().IsWhiteSpace()` and while the latter allocates less, it took actually longer to execute according to the contributor's own benchmark analysis.

Using String.IsNullOrWhiteSpace seems better here, because it shouldn't allocate either (vs `Trim()`) while it avoids calling `AsSpan()`, and the poor-man measurement stick I have so far is GitHub's CI runs: 3 jobs with the old codebase were slower than 1 job with this change.

[1] https://github.com/fsprojects/FSharpLint/pull/854