### PR TITLE
(minimal, patching-over fix) async rules crash under the TransparentCompiler

### DIFF
--- a/src/FSharpLint.Core/Application/Lint.fs
+++ b/src/FSharpLint.Core/Application/Lint.fs
@@ -265,9 +265,18 @@ module Lint =
                         GlobalConfig = enabledRules.GlobalConfig
                         TypeCheckResults = fileInfo.TypeCheckResults
                         ProjectCheckResults = fileInfo.ProjectCheckResults
-                        ProjectOptions = lazy( 
+                        // FSharpProjectContext.ProjectOptions is unavailable by design when
+                        // the check results come from FCS's TransparentCompiler (the getter
+                        // throws). Degrade to None so rules needing project options (e.g. the
+                        // library heuristics) fall back gracefully instead of failing the
+                        // whole file with an internal error.
+                        ProjectOptions = lazy(
                             fileInfo.ProjectCheckResults
-                            |> Option.map _.ProjectContext.ProjectOptions
+                            |> Option.bind (fun projectCheckResults ->
+                                try
+                                    Some projectCheckResults.ProjectContext.ProjectOptions
+                                with _ ->
+                                    None)
                         )
                         FilePath = fileInfo.File
                         FileContent = fileInfo.Text

--- a/tests/FSharpLint.FunctionalTest/TestApi.fs
+++ b/tests/FSharpLint.FunctionalTest/TestApi.fs
@@ -59,6 +59,56 @@ module TestApi =
             Assert.Less(result, 250)
             fprintf TestContext.Out "Average runtime of linter on parsed file: %d (milliseconds)."  result
 
+        /// Regression: analyzer hosts built on FCS's TransparentCompiler
+        /// supply ProjectCheckResults whose FSharpProjectContext.ProjectOptions getter
+        /// throws by design. Rules forcing the two-phase ProjectOptions lazy (the library
+        /// heuristics in AsynchronousFunctionNames & co.) then failed the whole file with
+        /// an internal error. The lazy must degrade to None instead.
+        [<Test>]
+        member _.``Lint parsed TransparentCompiler results without internal failure``() =
+            let source = "module TransparentCompilerRepro\n\nlet answer = async { return 42 }\n"
+            let transparentChecker = FSharpChecker.Create(keepAssemblyContents = true, useTransparentCompiler = true)
+            let sourceText = SourceText.ofString source
+
+            let (options, _diagnostics) =
+                transparentChecker.GetProjectOptionsFromScript(sourceFile, sourceText)
+                |> Async.RunSynchronously
+
+            let parseResults, checkAnswer =
+                transparentChecker.ParseAndCheckFileInProject(sourceFile, 0, sourceText, options)
+                |> Async.RunSynchronously
+
+            let checkResults =
+                match checkAnswer with
+                | FSharpCheckFileAnswer.Succeeded results -> results
+                | FSharpCheckFileAnswer.Aborted -> failwith "type check aborted"
+
+            let projectResults =
+                transparentChecker.ParseAndCheckProject options |> Async.RunSynchronously
+
+            let fileInfo =
+                { Ast = parseResults.ParseTree
+                  Source = source
+                  TypeCheckResults = Some checkResults
+                  ProjectCheckResults = Some projectResults }
+
+            let mutable internalFailure = None
+
+            let optionalParams =
+                { OptionalLintParameters.Default with
+                    ReportLinterProgress =
+                        Some (fun progress ->
+                            match progress with
+                            | ProjectProgress.Failed(_, ex) -> internalFailure <- Some ex
+                            | _ -> ()) }
+
+            match lintParsedFile optionalParams fileInfo sourceFile with
+            | LintResult.Success _ ->
+                match internalFailure with
+                | Some ex -> Assert.Fail $"lint failed internally: {ex}"
+                | None -> ()
+            | LintResult.Failure failure -> Assert.Fail(string failure)
+
         [<Test>]
         member _.``Lint project via absolute path``() =
             let projectPath = basePath </> "tests" </> "FSharpLint.FunctionalTest.TestedProject" </> "FSharpLint.FunctionalTest.TestedProject.NetCore"


### PR DESCRIPTION
> **SIMPLER of two alternative fixes for the same crash** — the COMPLETE alternative is **#863**, which preserves the rules' behavior under the TransparentCompiler at the cost of a small public-API addition. Mutually exclusive; pick one.

## When this happens

If you run FSharpLint **as a library** — the `lintParsedFile` / `lintParsedSource` API, passing your own `ProjectCheckResults` — and those results come from an `FSharpChecker` created with `useTransparentCompiler = true`, linting **aborts on otherwise-valid files** with an internal error. The trigger is the async/library-heuristic rules: `AsynchronousFunctionNames`, `SimpleAsyncComplementaryHelpers`, and `NoAsyncRunSynchronouslyInLibrary` (the first and last are on by default).

Concretely: in my project [FsHotWatch](https://github.com/michaelglass/FsHotWatch) I use FSharpLint as a library (not the CLI tool), reusing warm FCS check results to re-lint files on save. When I switched the underlying `FSharpChecker` to the TransparentCompiler, valid files started failing to lint with an internal error.

## Why

Those rules need the project file name. They get it through the two-phase `ProjectOptions` lazy (added in `91fd00b0`), which reads `FSharpProjectContext.ProjectOptions` — a getter that **throws by design** under the TransparentCompiler. Forcing the lazy then raises, and FSharpLint reports the whole file as failed.

## Fix

Wrap the single `ProjectOptions` lazy in `try … with _ -> None`, so those rules fall back to their non-project heuristics instead of failing the file. One change at the source of the shared lazy, so every rule that uses it benefits.

## Test

`TestApi.fs` regression: lints results produced by `FSharpChecker.Create(useTransparentCompiler = true)` and asserts no internal failure — it reproduces the crash without the fix and passes with it.

if it wasn't obvious from the tone of the PR: this work was done with the extensive help with AI, and then eyeballed / confirmed by a fleshy human being