### PR TITLE
NoPartialFunctions: fixed bug on object expressions

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/NoPartialFunctions.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/NoPartialFunctions.fs
@@ -173,7 +173,7 @@ let rec private tryFindTypedExpression (range: Range) (expressions: List<FSharpE
             |> List.collect (fun (_, imlps) -> imlps)
         let exprs =
             List.append overrides interfaceImlps
-            |> Seq.cast<FSharpExpr>
+            |> Seq.map (fun expr -> expr.Body)
             |> Seq.toList
         tryFindTypedExpression range (baseCallExpr :: exprs @ rest)
     | FSharpExprPatterns.TraitCall(_sourceTypes, _traitName, _typeArgs, _typeInstantiation, _argTypes, argExprs) :: rest -> 

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
@@ -182,6 +182,24 @@ module Program =
 """
 
         this.AssertNoWarnings()
+
+    [<Test>]
+    member this.``Regression test for object expressions``() =
+        this.Parse """
+type Foo =
+    abstract Bar: unit -> unit
+
+let host = 
+    { new Foo with
+        member _.Bar() =
+            () }
+
+let x = 
+    JsonDocument.Parse(responseBody).RootElement |> ignore
+    Option.ofObj(host).Value
+"""
+        
+        Assert.IsTrue this.ErrorsExist
 (*
     // Examples for future additions, see 'Foo.Bar.Baz' in partialInstanceMemberIdentifiers in .Core/.../NoPartialFunctions.fs
 


### PR DESCRIPTION
By removing incorrect type cast.

Also added a regression test.