### PR TITLE
NoPartialFunctions: add Seq.cast to list of partial function identifiers

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/NoPartialFunctions.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/NoPartialFunctions.fs
@@ -57,6 +57,7 @@ let private partialFunctionIdentifiers =
             ("Seq.reduce", Function "Seq.fold")
             ("Seq.reduceBack", Function "Seq.foldBack")
             ("Seq.pick", Function "Seq.tryPick")
+            ("Seq.cast", Function "Seq.choose tryUnbox")
 
             // List
             ("List.exactlyOne", Function "List.tryExactlyOne")

--- a/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Conventions/NoPartialFunctions.fs
@@ -172,6 +172,16 @@ if foo.Head 1 then
         this.AssertErrorWithMessageExists("Consider using 'List.tryHead' instead of partial function/method 'List.Head'.")
 
     [<Test>]
+    member this.``Error for Seq.cast``() =
+        this.Parse """
+let foo = [ box "Hello"; box 42 ]
+let bar = Seq.cast<string> foo
+"""
+
+        Assert.IsTrue this.ErrorsExist
+        this.AssertErrorWithMessageExists("Consider using 'Seq.choose tryUnbox' instead of partial function/method 'Seq.cast'.")
+
+    [<Test>]
     member this.``Regression found when parsing Console/Program_fs``() =
         this.Parse """
 module Program =


### PR DESCRIPTION
`Seq.cast` is a partial function because it will raise an exception at runtime if one of the elements can't be cast to specified type.
`Seq.choose tryUnbox` is proposed as an alternative.