### PR TITLE
NoAsyncRunSynchronouslyInLibrary: don't apply in scripts

### DIFF
--- a/docs/content/how-tos/rules/FL0090.md
+++ b/docs/content/how-tos/rules/FL0090.md
@@ -16,6 +16,7 @@ The rule assumes the code is in the library if none of the following is true:
 - The code is inside NUnit or MSTest test.
 - Namespace or project name contains "test" or "console".
 - Assembly has `[<EntryPoint>]` attribute one one of the functions/methods.
+- The source file is a script file (has ".fsx" extension).
 
 ## Rationale
 

--- a/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
+++ b/src/FSharpLint.Core/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
@@ -93,6 +93,8 @@ let isInObsoleteMethodOrFunction parents =
 
 let checkIfInLibrary (args: AstNodeRuleParams) (range: range) : array<WarningDetails> =
     let ruleNotApplicable =
+        args.FilePath.EndsWith ".fsx"
+        ||
         isInObsoleteMethodOrFunction (args.GetParents args.NodeIndex)
         ||
         match (args.CheckInfo, args.ProjectOptions.Value) with

--- a/tests/FSharpLint.Core.Tests/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Smells/NoAsyncRunSynchronouslyInLibrary.fs
@@ -133,6 +133,17 @@ let Foo() =
 
         this.AssertNoWarnings()
 
+    [<Test>]
+    member this.``Async.RunSynchronously may be used in .fsx files``() =
+        this.Parse("""
+async {
+    return ()
+}
+|> Async.RunSynchronously""",
+            "script.fsx")
+
+        this.AssertNoWarnings()
+
 [<TestFixture>]
 type TestNoAsyncRunSynchronouslyInLibraryHeuristic() =
 


### PR DESCRIPTION
Don't apply rule in .fsx scripts because scripts are not library code.