### PR TITLE
tests(Benchmarks): Enable allocation reporting in the lint benchmark

### DIFF
--- a/tests/FSharpLint.Benchmarks/Benchmark.fs
+++ b/tests/FSharpLint.Benchmarks/Benchmark.fs
@@ -8,6 +8,7 @@ open FSharpLint.Application.Lint
 open FSharpLint.Framework
 open FSharpLint.Framework.Utilities
 
+[<MemoryDiagnoser>]
 type Benchmark () =
 
     let generateAst source sourceFile =


### PR DESCRIPTION
This allows the benchmark project to be used to test changes intended to reduce memory allocations