### PR TITLE
perf(Core/SourceLength): Change Substring to Span

### DIFF
--- a/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
+++ b/src/FSharpLint.Core/Rules/Conventions/SourceLength/SourceLengthHelper.fs
@@ -54,8 +54,9 @@ let checkSourceLengthRule (config:Config) range fileContents errorName (skipRang
         getTopLevelBalancedPairs markers List.Empty
         |> List.fold
             (fun (currSource: string) (startIndex, endIndex) ->
-                currSource.Substring(0, startIndex) 
-                + currSource.Substring(endIndex + multilineCommentMarkerRegexCaptureGroupLength))
+                let left = currSource.AsSpan(0, startIndex) 
+                let right = currSource.AsSpan(endIndex + multilineCommentMarkerRegexCaptureGroupLength)
+                String.Concat(left, right))
             source
 
     match tryFindTextOfRange range fileContents with


### PR DESCRIPTION
I was looking at this when I opened https://github.com/fsprojects/FSharpLint/issues/869 - leaving it as a draft for now due to that
--------------

Creating two substrings and then joining them allocates 3 strings, but creating two spans and concatenating those only allocates one, which can be a substantial saving on large files.

Running the benchmarks with the extended set of 'self check' rules enabled gives me -

Before:
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.467 s | 0.0287 s | 0.0282 s | 36000.0000 | 12000.0000 | 3000.0000 |    622 MB |

After:
| Method         | Mean    | Error    | StdDev   | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |--------:|---------:|---------:|-----------:|-----------:|----------:|----------:|
| LintParsedFile | 1.433 s | 0.0085 s | 0.0076 s | 35000.0000 | 11000.0000 | 2000.0000 | 588.75 MB |