### PR TITLE
Remove conditionless reduction hint

### DIFF
--- a/src/FSharpLint.Core/fsharplint.json
+++ b/src/FSharpLint.Core/fsharplint.json
@@ -431,7 +431,6 @@
             "false <> a ===> a",
             "if a then true else false ===> a",
             "if a then false else true ===> not a",
-            "if x then y else y ===> y",
             "not (not x) ===> x",
 
             "(fst x, snd x) ===> x",

--- a/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
@@ -1019,6 +1019,7 @@ let foo =
         Assert.That this.NoErrorsExist
 
     [<Test>]
+    [<Ignore("Fixing it would take a lot of work since AbstractSyntaxArray.getHashCode function would have to be defined for all expression types.")>]
     member this.``Records with different data (not a literal constant) should be treated as diffrerent``() =
         this.SetConfig(["if x then y else y ===> y"])
 

--- a/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
+++ b/tests/FSharpLint.Core.Tests/Rules/Hints/HintMatcher.fs
@@ -1017,3 +1017,30 @@ let foo =
 """
         
         Assert.That this.NoErrorsExist
+
+    [<Test>]
+    member this.``Records with different data (not a literal constant) should be treated as diffrerent``() =
+        this.SetConfig(["if x then y else y ===> y"])
+
+        this.Parse """
+type Foo =
+    | Bar
+    | Baz
+
+type Record =
+    {
+        Foo: Foo
+    }
+
+let foo =
+    if 2 = 2 then
+        {
+            Foo = Bar
+        }
+    else
+        {
+            Foo = Baz
+        }
+"""
+        
+        Assert.That this.NoErrorsExist


### PR DESCRIPTION
Removed conditionless reduction ("if x then y else y ===> y") hint because it caused false positives on records.

Fixing it would take a lot of work since AbstractSyntaxArray.getHashCode function would have to be defined for all expression types (there are about 60 of them).

A test with `[<Ignore>]` attribute was added as an example of such false positive.